### PR TITLE
Fix issues with MaxQuant and Fragpipe tables

### DIFF
--- a/alphaquant/config/quant_reader_config.yaml
+++ b/alphaquant/config/quant_reader_config.yaml
@@ -144,36 +144,63 @@ maxquant_peptides_leading_razor_protein:
 
 maxquant_evidence:
   format: longtable
-  sample_ID: Experiment #Raw file
-  quant_ID: Intensity
+  sample_ID: Experiment
+  quant_ID:
+    precursor: Intensity
   protein_cols:
    - Gene names
-  ion_cols:
-   - Modified sequence
-   - Charge
+  ion_hierarchy:
+    precursor:
+      order: [SEQ, MOD, CHARGE]
+      mapping:
+        SEQ:
+          - Sequence
+        MOD:
+          - Mass
+        CHARGE:
+          - Charge
+  filters:
+    reverse:
+      param: Reverse
+      comparator: "!="
+      value: "+"
+    contaminant:
+      param: Potential contaminant
+      comparator: "!="
+      value: "+"
+  ml_level: SEQ
+  use_iontree: False
+
 
 maxquant_evidence_protein:
   format: longtable
-  sample_ID: Experiment #Raw file
-  quant_ID: Intensity
+  sample_ID: Experiment
+  quant_ID:
+    precursor: Intensity
   protein_cols:
    - Protein group IDs
-  ion_cols:
-   - Modified sequence
-   - Charge
+  ion_hierarchy:
+    precursor:
+      order: [SEQ, MOD, CHARGE]
+      mapping:
+        SEQ:
+          - Sequence
+        MOD:
+          - Mass
+        CHARGE:
+          - Charge
+  filters:
+    reverse:
+      param: Reverse
+      comparator: "!="
+      value: "+"
+    contaminant:
+      param: Potential contaminant
+      comparator: "!="
+      value: "+"
+  ml_level: SEQ
+  use_iontree: False
 
-
-
-maxquant_evidence_proteins_column:
-  format: longtable
-  sample_ID: Experiment #Raw file
-  quant_ID: Intensity
-  protein_cols:
-   - Proteins
-  ion_cols:
-   - Sequence
-   - Modifications
-   - Charge
 
 diann_precursor_fragion_ms1:
   format: longtable
@@ -1260,27 +1287,6 @@ diaumpire_precursor_ms1:
   ion_cols:
    - Peptide Key
 
-
-diann_wideformat:
-  format: widetable
-  protein_cols:
-   - Protein.Group
-  ion_cols:
-   - Stripped.Sequence
-   - Modified.Sequence
-   - Precursor.Charge
-  ion_hierarchy:
-    sequence_int:
-      order: [SEQ, MOD]
-      mapping:
-        SEQ:
-          - Stripped.Sequence
-        MOD:
-          - Modified.Sequence
-        CH:
-          - Precursor.Charge
-  ml_level: SEQ
-  use_iontree: False
 
 fragpipe_precursors:
   format: widetable

--- a/alphaquant/diffquant/condpair_analysis.py
+++ b/alphaquant/diffquant/condpair_analysis.py
@@ -49,7 +49,7 @@ def analyze_condpair(*,runconfig, condpair):
         write_out_normed_df(df_c1_normed, df_c2_normed, pep2prot, runconfig.results_dir, condpair)
     normed_c1 = aqbg.ConditionBackgrounds(df_c1_normed, p2z)
     normed_c2 = aqbg.ConditionBackgrounds(df_c2_normed, p2z)
-    
+
     ions_to_check = normed_c1.ion2nonNanvals.keys() & normed_c2.ion2nonNanvals.keys()
     ions_to_check = sorted(ions_to_check)
 
@@ -82,16 +82,16 @@ def analyze_condpair(*,runconfig, condpair):
         ions = prot2diffions.get(prot)
         if len(ions)<runconfig.min_num_ions:
             continue
-        
-        clustered_prot_node = aqclust.get_scored_clusterselected_ions(prot, ions, normed_c1, normed_c2, bgpair2diffDist, p2z, deedpair2doublediffdist, 
-                                                                        pval_threshold_basis = runconfig.cluster_threshold_pval, fcfc_threshold = runconfig.cluster_threshold_fcfc, 
+
+        clustered_prot_node = aqclust.get_scored_clusterselected_ions(prot, ions, normed_c1, normed_c2, bgpair2diffDist, p2z, deedpair2doublediffdist,
+                                                                        pval_threshold_basis = runconfig.cluster_threshold_pval, fcfc_threshold = runconfig.cluster_threshold_fcfc,
                                                                         take_median_ion=runconfig.take_median_ion, fcdiff_cutoff_clustermerge= runconfig.fcdiff_cutoff_clustermerge)
         protnodes.append(clustered_prot_node)
 
         if count_prots%100==0:
             LOGGER.info(f"checked {count_prots} of {len(prot2diffions.keys())} prots")
         count_prots+=1
-    
+
     if len(prot2missingval_diffions.keys())>0:
         LOGGER.info(f"start analysis of proteins w. completely missing values")
 
@@ -102,13 +102,13 @@ def analyze_condpair(*,runconfig, condpair):
             ions = prot2missingval_diffions.get(prot)
             protnode_missingval = aq_clust_missingval.create_protnode_from_missingval_ions(gene_name=prot,diffions=ions, normed_c1=normed_c1, normed_c2=normed_c2)
             protnodes_missingval.append(protnode_missingval)
-        
+
         LOGGER.info(f"finished missing value analysis")
 
     if runconfig.use_ml:
         ml_performance_dict = {}
 
-        #aq_class_stacked_frag.assign_predictability_scores_stacked(protein_nodes= protnodes, acquisition_info_df=None,results_dir=runconfig.results_dir, name = aqutils.get_condpairname(condpair)+"_fragions", 
+        #aq_class_stacked_frag.assign_predictability_scores_stacked(protein_nodes= protnodes, acquisition_info_df=None,results_dir=runconfig.results_dir, name = aqutils.get_condpairname(condpair)+"_fragions",
          #                           min_num_fragions=5, replace_nans=True, performance_metrics=ml_performance_dict, plot_predictor_performance=True)
         ml_successfull =aq_class_precursors.assign_predictability_scores(protein_nodes= protnodes, results_dir=runconfig.results_dir, name = aqutils.get_condpairname(condpair), ml_info_file=runconfig.ml_input_file,
                                         samples_used =c1_samples + c2_samples, min_num_precursors=3, prot_fc_cutoff=0, replace_nans=True, performance_metrics=ml_performance_dict, plot_predictor_performance=runconfig.runtime_plots)
@@ -159,10 +159,10 @@ def get_per_condition_dataframes(samples_c1, samples_c2, unnormed_df, minrep_bot
 
     if min_samples<2:
         raise Exception(f"condpair has not enough samples: c1:{len(samples_c1)} c2: {len(samples_c2)}, skipping")
-    
+
     if (minrep_either is not None) or ((minrep_c1 is not None) and (minrep_c2 is not None)): #minrep_both was set as default and should be overruled by minrep_either or minrep_c1 and minrep_c2
         minrep_both = None
-            
+
     if minrep_either is not None:
         minrep_either = np.min([get_minrep_for_cond(samples_c1, minrep_either), get_minrep_for_cond(samples_c2, minrep_either)])
         passes_minrep_c1 = unnormed_df.loc[:, samples_c1].notna().sum(axis=1) >= minrep_either
@@ -184,7 +184,7 @@ def get_per_condition_dataframes(samples_c1, samples_c2, unnormed_df, minrep_bot
         df_c2 = unnormed_df.loc[:, samples_c2].dropna(thresh=minrep_c2, axis=0)
         if (len(df_c1.index)<5) | (len(df_c2.index)<5):
             raise Exception(f"condpair has not enough data for processing c1: {len(df_c1.index)} c2: {len(df_c2.index)}, skipping")
-        
+
     if (minrep_both is None) and (minrep_either is None) and (minrep_c1 is None) and (minrep_c2 is None):
         raise Exception("no minrep set, please specify!")
 
@@ -200,13 +200,13 @@ def get_minrep_for_cond(c_samples, minrep):
         return num_samples
     else:
         return minrep
-    
 
-    
+
+
 
 def write_out_tables(condpair_node, runconfig):
     condpair = condpair_node.name
-    
+
     res_df = aq_tablewriter_protein.TableFromNodeCreator(condpair_node, node_type = "gene", min_num_peptides = runconfig.minpep, annotation_file= getattr(runconfig, "annotation_file", None)).results_df
     has_sequence_nodes = check_if_has_sequence_nodes(condpair_node)
     if has_sequence_nodes:
@@ -235,14 +235,17 @@ def write_out_tables(condpair_node, runconfig):
         res_df.to_csv(f"{runconfig.results_dir}/{aqutils.get_condpairname(condpair)}.results.tsv", sep = "\t", index=None)
         if has_sequence_nodes:
             pep_df.to_csv(f"{runconfig.results_dir}/{aqutils.get_condpairname(condpair)}.results.seq.tsv", sep = "\t", index=None)
-        
+
         if has_precursor_nodes:
             prec_df.to_csv(f"{runconfig.results_dir}/{aqutils.get_condpairname(condpair)}.results.prec.tsv", sep = "\t", index=None)
-        
+
     return res_df, pep_df
 
 def check_if_has_sequence_nodes(condpair_node):
     return condpair_node.children[0].children[0].type == "seq"
 
 def check_if_has_precursor_nodes(condpair_node):
-    return condpair_node.children[0].children[0].children[0].children[0].type == "mod_seq_charge"
+    try:
+        return condpair_node.children[0].children[0].children[0].children[0].type == "mod_seq_charge"
+    except:
+        return False

--- a/alphaquant/ui/dashboard_parts_run_pipeline.py
+++ b/alphaquant/ui/dashboard_parts_run_pipeline.py
@@ -18,6 +18,7 @@ import alphaquant.ui.dashboad_parts_plots_basic as dashboad_parts_plots_basic
 import alphaquant.ui.dashboard_parts_plots_proteoforms as dashboad_parts_plots_proteoforms
 import alphaquant.ui.gui as gui
 import alphaquant.ui.gui_textfields as gui_textfields
+import alphaquant.utils.reader_utils as aq_reader_utils
 
 import alphabase.quantification.quant_reader.config_dict_loader as config_dict_loader
 config_dict_loader.INTABLE_CONFIG = os.path.join(pathlib.Path(__file__).parent.absolute(), "../config/quant_reader_config.yaml")
@@ -889,12 +890,13 @@ class RunPipeline(BaseWidget):
 				if config_dict["format"] == "longtable":
 					sample_column = config_dict["sample_ID"]
 					sample_names = set()
-					for chunk in pd.read_csv(input_file, sep=sep, usecols=[sample_column], chunksize=400000):
+
+					for chunk in aq_reader_utils.read_file(input_file, sep=sep, usecols=[sample_column], chunksize=400000):
 						sample_names.update(chunk[sample_column].unique())
 					self.sample_names = sample_names
 				elif config_dict["format"] == "widetable":
 					# Read the headers first to identify sample columns
-					headers = pd.read_csv(input_file, sep=sep, nrows=0).columns.tolist()
+					headers = aq_reader_utils.read_file(input_file, sep=sep, nrows=0).columns.tolist()
 
 					quant_pre_or_suffix = config_dict.get("quant_pre_or_suffix")
 					# Filter headers to find those with the prefix or suffix
@@ -911,6 +913,7 @@ class RunPipeline(BaseWidget):
 					self.run_pipeline_error.visible = True
 
 			except Exception as e:
+				print(f"Error importing data: {e}")
 				self.run_pipeline_error.object = f"Error importing data: {e}"
 				self.run_pipeline_error.visible = True
 			finally:

--- a/alphaquant/ui/dashboard_parts_run_pipeline.py
+++ b/alphaquant/ui/dashboard_parts_run_pipeline.py
@@ -20,7 +20,7 @@ import alphaquant.ui.gui as gui
 import alphaquant.ui.gui_textfields as gui_textfields
 
 import alphabase.quantification.quant_reader.config_dict_loader as config_dict_loader
-config_dict_loader.INTABLE_CONFIG = os.path.join(pathlib.Path(__file__).parent.absolute(), "../config/quant_reader_config_lightweight.yaml")
+config_dict_loader.INTABLE_CONFIG = os.path.join(pathlib.Path(__file__).parent.absolute(), "../config/quant_reader_config.yaml")
 # If using Plotly in Panel
 pn.extension('plotly')
 
@@ -1127,6 +1127,7 @@ class RunPipeline(BaseWidget):
 				self.state.notify_subscribers('samplemap_df')
 
 			except Exception as e:
+				print(f"Error reading sample map: {str(e)}")
 				self.run_pipeline_error.object = f"Error reading sample map: {str(e)}"
 				self.run_pipeline_error.visible = True
 
@@ -1156,6 +1157,10 @@ class RunPipeline(BaseWidget):
 				self.template_success_message.object = f"""Template has been generated. Please fill out the condition column in the table below.\nThe template has also been saved to
 				<code>{template_path}</code>\nif you prefer to edit it with Excel or other applications."""
 				self.template_success_message.visible = True
+		except Exception as e:
+			print(f"Error generating sample map: {str(e)}")
+			self.run_pipeline_error.object = f"Error generating sample map: {str(e)}"
+			self.run_pipeline_error.visible = True
 		finally:
 			# Hide loading indicators when done
 			self.loading_samples_indicator.visible = False

--- a/alphaquant/utils/reader_utils.py
+++ b/alphaquant/utils/reader_utils.py
@@ -4,9 +4,11 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-def read_file(file_path, decimal=".", usecols=None, chunksize=None, sep=None):
+def read_file(file_path, decimal=".", usecols=None, chunksize=None, sep=None, nrows=None):
     file_path = str(file_path)
     if ".parquet" in file_path:
+        if nrows is not None:
+            LOGGER.warning(f"nrows parameter is set, but not supported for parquet files. Ignoring nrows parameter.")
         return _read_parquet_file(file_path, usecols=usecols, chunksize=chunksize)
     else:
         if sep is None:
@@ -26,6 +28,7 @@ def read_file(file_path, decimal=".", usecols=None, chunksize=None, sep=None):
             usecols=usecols,
             encoding="latin1",
             chunksize=chunksize,
+            nrows=nrows,
         )
 
 

--- a/tests/e2e_tests_small/different_input_tables.ipynb
+++ b/tests/e2e_tests_small/different_input_tables.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEST_FILE_DIR = \"../../test_data/quicktests/quant_reader_tables\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import alphabase.tools.data_downloader as ab_data_downloader\n",
+    "\n",
+    "downloader = ab_data_downloader.DataShareDownloader(\"https://datashare.biochem.mpg.de/s/8OQTYwtKkpVwOys\", output_dir=f\"{TEST_FILE_DIR}/..\")#this downloads the folder quant_reader_tables into the specified path\n",
+    "\n",
+    "downloader.download()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import os\n",
+    "import alphaquant.run_pipeline as aq_run_pipeline\n",
+    "\n",
+    "input_files = [ \"diann.parquet\",\"spectronaut.frgions.large.tsv\", \"mq_peptides.txt\", \"mq_evidence.txt\", \"fragpipe.tsv\"]\n",
+    "samplemap_map = {\n",
+    "\t\"diann.parquet\": f\"{TEST_FILE_DIR}/samplemap_diann_parquet.tsv\",\n",
+    "\t\"spectronaut.frgions.large.tsv\": f\"{TEST_FILE_DIR}/samplemap_spectronaut.tsv\",\n",
+    "\t\"mq_peptides.txt\": f\"{TEST_FILE_DIR}/samplemap_maxquant.tsv\",\n",
+    "\t\"mq_evidence.txt\": f\"{TEST_FILE_DIR}/samplemap_maxquant.tsv\",\n",
+    "\t\"fragpipe.tsv\": f\"{TEST_FILE_DIR}/samplemap_fragpipe.tsv\"\n",
+    "}\n",
+    "results_dir_map = {\n",
+    "\t\"diann.tsv\": f\"{TEST_FILE_DIR}/results_diann_tsv\",\n",
+    "\t\"diann.parquet\": f\"{TEST_FILE_DIR}/results_diann_parquet\",\n",
+    "\t\"spectronaut.frgions.large.tsv\": f\"{TEST_FILE_DIR}/results_spectronaut\",\n",
+    "\t\"mq_peptides.txt\": f\"{TEST_FILE_DIR}/results_mq_peptides\",\n",
+    "\t\"mq_evidence.txt\": f\"{TEST_FILE_DIR}/results_mq_evidence\",\n",
+    "\t\"fragpipe.tsv\": f\"{TEST_FILE_DIR}/results_fragpipe\"\n",
+    "}\n",
+    "\n",
+    "for input_file in input_files:\n",
+    "\tif input_file ==\"fragpipe.tsv\":\n",
+    "\t\taq_run_pipeline.run_pipeline(input_file=os.path.join(TEST_FILE_DIR, input_file), samplemap_file=samplemap_map[input_file], results_dir=results_dir_map[input_file], reset_progress_folder=True, multicond_median_analysis=True)\n",
+    "\telse:\n",
+    "\t\taq_run_pipeline.run_pipeline(input_file=os.path.join(TEST_FILE_DIR, input_file), samplemap_file=samplemap_map[input_file], results_dir=results_dir_map[input_file], reset_progress_folder=True)\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/e2e_tests_small/different_input_tables.ipynb
+++ b/tests/e2e_tests_small/different_input_tables.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TEST_FILE_DIR = \"../../test_data/quicktests/quant_reader_tables\"\n"
+    "TEST_FILE_DIR = \"../../test_data/quicktests/input_table_formats\"\n"
    ]
   },
   {
@@ -17,7 +17,7 @@
    "source": [
     "import alphabase.tools.data_downloader as ab_data_downloader\n",
     "\n",
-    "downloader = ab_data_downloader.DataShareDownloader(\"https://datashare.biochem.mpg.de/s/8OQTYwtKkpVwOys\", output_dir=f\"{TEST_FILE_DIR}/..\")#this downloads the folder quant_reader_tables into the specified path\n",
+    "downloader = ab_data_downloader.DataShareDownloader(\"https://datashare.biochem.mpg.de/s/UiyNiR9SlWXJ6qM\", output_dir=f\"{TEST_FILE_DIR}/..\")#this downloads the folder input_table_formats from the AlphaX data share into the specified path\n",
     "\n",
     "downloader.download()"
    ]
@@ -41,7 +41,6 @@
     "\t\"fragpipe.tsv\": f\"{TEST_FILE_DIR}/samplemap_fragpipe.tsv\"\n",
     "}\n",
     "results_dir_map = {\n",
-    "\t\"diann.tsv\": f\"{TEST_FILE_DIR}/results_diann_tsv\",\n",
     "\t\"diann.parquet\": f\"{TEST_FILE_DIR}/results_diann_parquet\",\n",
     "\t\"spectronaut.frgions.large.tsv\": f\"{TEST_FILE_DIR}/results_spectronaut\",\n",
     "\t\"mq_peptides.txt\": f\"{TEST_FILE_DIR}/results_mq_peptides\",\n",

--- a/tests/run_e2e_tests_quick.sh
+++ b/tests/run_e2e_tests_quick.sh
@@ -3,4 +3,5 @@ conda activate alphaquant
 echo "Running e2e tests quick"
 pytest --nbmake e2e_tests_small/mixed_species.ipynb
 pytest --nbmake e2e_tests_small/phospho.ipynb
+pytest --nbmake e2e_tests_small/different_input_tables.ipynb
 conda deactivate


### PR DESCRIPTION
Addressing issue #85 
- Changed the intable config for the GUI back to the default version also used in the python version
- Update config for MaxQuant evidence.txt
- Extend sample name extraction in GUI to parquet files
- Extend sample name extraction in GUI to wideformat tables (MaxQuant peptides.txt and fragpipe)
- Disable ML for wideformat tables
- Add quicktests that run short AlphaQuant runs on different MQ, Fragpipe, DIA-NN, Spectronaut