### PR TITLE
Add variance predictor module

### DIFF
--- a/alphaquant/diffquant/variance_predictor.py
+++ b/alphaquant/diffquant/variance_predictor.py
@@ -1,0 +1,200 @@
+"""Variance-predictor scoring for background-distribution ion ordering.
+
+Loads quality-metric columns from the ml_info_table (at precursor level)
+and fits a linear model predicting observed per-ion variance from these
+metrics.  The predicted variance is used to sort ions so that those with
+similar expected variance are grouped together, producing tighter
+empirical background distributions.
+
+The linear-regression approach automatically handles columns that
+correlate with variance in different directions (positive or negative
+coefficients) and weights each column by its predictive power.
+"""
+
+import re
+import logging
+
+import numpy as np
+import pandas as pd
+
+import alphaquant.utils.reader_utils as aq_reader_utils
+
+LOGGER = logging.getLogger(__name__)
+
+_ION_SPLIT_PAT = re.compile(r"(_FRGION_|_MS1ISOTOPES_|_PRECURSOR_)")
+
+
+def load_variance_predictor_scores(ml_info_file, samples_used,
+                                   variance_predictor_cols, ion_index,
+                                   ion_variance, ion_median_intensity=None):
+    """Fit a linear model predicting observed ion variance from quality
+    metrics and return the predicted scores for sorting.
+
+    The ml_info_table is at precursor level (SEQ_MOD_CHARGE).  Fragment-level
+    ion ids are mapped to their parent precursor via ``_ION_SPLIT_PAT``.
+
+    A simple OLS regression is fitted::
+
+        ion_variance ~ median_intensity + col1 + col2 + ...
+
+    Median intensity is always included as a built-in predictor (when
+    provided) because it is the strongest single correlate of ion-level
+    variance.  The quality-metric columns from the config refine this
+    baseline.  The predicted values serve as the combined score.
+
+    Args:
+        ml_info_file (str): Path to the ml_info_table TSV.
+        samples_used (list[str] | None): Sample IDs to keep; None keeps all.
+        variance_predictor_cols (list[str]): Column names in the ml_info_table
+            to use as predictors.
+        ion_index (pd.Index): Ion identifiers to score.
+        ion_variance (pd.Series): Observed per-ion variance (indexed by ion id),
+            used as the regression target.
+        ion_median_intensity (pd.Series | None): Per-ion pooled median
+            intensity.  When provided, prepended as a built-in predictor.
+
+    Returns:
+        dict[str, float] | None: Mapping from ion id to predicted variance
+            score, or None if the required columns were not found or the
+            regression could not be fitted.
+    """
+    if not variance_predictor_cols:
+        return None
+
+    try:
+        usecols = ["quant_id", "sample_ID"] + list(variance_predictor_cols)
+        ml_df = aq_reader_utils.read_file(ml_info_file, sep="\t", usecols=usecols)
+    except (ValueError, KeyError):
+        LOGGER.warning(
+            "Could not load variance predictor columns %s from %s. "
+            "Falling back to intensity-only background sorting.",
+            variance_predictor_cols, ml_info_file,
+        )
+        return None
+
+    if samples_used is not None:
+        ml_df = ml_df[ml_df["sample_ID"].isin(samples_used)]
+    ml_df = ml_df.drop(columns=["sample_ID"])
+
+    for col in variance_predictor_cols:
+        ml_df[col] = pd.to_numeric(ml_df[col], errors="coerce")
+
+    available_cols = [c for c in variance_predictor_cols if c in ml_df.columns]
+    if not available_cols:
+        LOGGER.warning("None of the variance predictor columns found. Falling back.")
+        return None
+
+    prec_features = ml_df.groupby("quant_id")[available_cols].median()
+
+    ion_strings = np.array([str(x) for x in ion_index])
+    precursor_ids = np.array([_ION_SPLIT_PAT.split(s)[0] for s in ion_strings])
+
+    scores = _fit_and_predict(prec_features, available_cols,
+                              precursor_ids, ion_index, ion_variance,
+                              ion_median_intensity)
+    if scores is None:
+        return None
+
+    all_cols = (["median_intensity"] if ion_median_intensity is not None
+                else []) + available_cols
+    ion2varscore = dict(zip(ion_index, scores))
+    LOGGER.info(
+        "Variance predictor scores computed for %d/%d ions using columns %s",
+        np.isfinite(scores).sum(), len(ion_index), all_cols,
+    )
+    return ion2varscore
+
+
+def _fit_and_predict(prec_features, available_cols, precursor_ids,
+                     ion_index, ion_variance,
+                     ion_median_intensity=None):
+    """Build feature matrix, fit OLS on observed variance, return predictions.
+
+    Median intensity (when provided) is always prepended as the first
+    predictor column because it is typically the strongest correlate of
+    ion-level variance.  The quality-metric columns refine the prediction.
+
+    Ions with missing features or missing variance are excluded from fitting
+    but receive the median predicted score as fallback.
+
+    Args:
+        prec_features (pd.DataFrame): Precursor-level feature medians
+            (index = quant_id, columns = available_cols).
+        available_cols (list[str]): Column names to use as predictors.
+        precursor_ids (np.ndarray): Precursor id for each ion in ion_index.
+        ion_index (pd.Index): Ion identifiers.
+        ion_variance (pd.Series): Observed per-ion variance.
+        ion_median_intensity (pd.Series | None): Per-ion pooled median
+            intensity.  When provided, used as a built-in first predictor.
+
+    Returns:
+        np.ndarray of predicted scores (length = len(ion_index)), or None
+        if the regression cannot be fitted.
+    """
+    n_ions = len(ion_index)
+    n_cols = len(available_cols)
+
+    X = np.full((n_ions, n_cols), np.nan)
+    for j, col in enumerate(available_cols):
+        col_vals = prec_features[col]
+        X[:, j] = [col_vals.get(pid, np.nan) for pid in precursor_ids]
+
+    if ion_median_intensity is not None:
+        intensity_col = np.array(
+            [ion_median_intensity.get(ion, np.nan) for ion in ion_index],
+            dtype=float,
+        ).reshape(-1, 1)
+        X = np.column_stack([intensity_col, X])
+        all_col_names = ["median_intensity"] + list(available_cols)
+    else:
+        all_col_names = list(available_cols)
+
+    n_features = X.shape[1]
+
+    y = np.array([ion_variance.get(ion, np.nan) for ion in ion_index],
+                 dtype=float)
+
+    valid = np.isfinite(X).all(axis=1) & np.isfinite(y)
+    if valid.sum() < max(10, n_features + 1):
+        LOGGER.warning(
+            "Too few valid ions (%d) for variance predictor regression. "
+            "Falling back to intensity-only sorting.", valid.sum()
+        )
+        return None
+
+    X_fit = X[valid]
+    y_fit = y[valid]
+
+    # Standardise features for numerical stability
+    X_mean = X_fit.mean(axis=0)
+    X_std = X_fit.std(axis=0)
+    X_std[X_std < 1e-15] = 1.0
+    X_fit_z = (X_fit - X_mean) / X_std
+
+    # OLS with intercept: y = X_z @ beta + intercept
+    X_design = np.column_stack([np.ones(X_fit_z.shape[0]), X_fit_z])
+    try:
+        beta, _, _, _ = np.linalg.lstsq(X_design, y_fit, rcond=None)
+    except np.linalg.LinAlgError:
+        LOGGER.warning("OLS fit failed for variance predictor. Falling back.")
+        return None
+
+    LOGGER.info(
+        "Variance predictor coefficients (standardised): %s",
+        dict(zip(all_col_names, beta[1:])),
+    )
+
+    # Predict for all ions (including those excluded from fit)
+    X_all_z = (X - X_mean) / X_std
+    X_all_design = np.column_stack([np.ones(n_ions), X_all_z])
+    predicted = X_all_design @ beta
+
+    # Fallback for ions with missing features
+    finite_mask = np.isfinite(predicted)
+    if finite_mask.any():
+        median_pred = np.median(predicted[finite_mask])
+    else:
+        median_pred = 0.0
+    predicted = np.where(finite_mask, predicted, median_pred)
+
+    return predicted

--- a/tests/unit_tests/test_variance_predictor.py
+++ b/tests/unit_tests/test_variance_predictor.py
@@ -1,0 +1,413 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import alphaquant.diffquant.variance_predictor as aq_vp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+N = 20  # enough ions to pass the min-10 threshold
+
+
+def _precursor_ids(n=N):
+    return [f"PREC{i}_MOD{i}_{i}" for i in range(n)]
+
+
+def _ion_index(precursor_ids):
+    """One fragment ion per precursor — keeps precursor mapping trivial."""
+    return pd.Index([f"{pid}_FRGION_y1" for pid in precursor_ids])
+
+
+def _write_ml_info(tmp_path, precursor_ids, columns_dict, samples=("S1", "S2")):
+    """Write a synthetic ml_info_table TSV and return its path."""
+    rows = []
+    for i, pid in enumerate(precursor_ids):
+        for s in samples:
+            row = {"quant_id": pid, "sample_ID": s}
+            for col, vals in columns_dict.items():
+                row[col] = vals[i]
+            rows.append(row)
+    df = pd.DataFrame(rows)
+    path = tmp_path / "ml_info.tsv"
+    df.to_csv(path, sep="\t", index=False)
+    return str(path)
+
+
+def _make_ion_variance(ion_index, values):
+    """Build an ion_variance Series aligned with ion_index."""
+    return pd.Series(values, index=ion_index)
+
+
+def _make_ion_median_intensity(ion_index, values):
+    """Build an ion_median_intensity Series aligned with ion_index."""
+    return pd.Series(values, index=ion_index)
+
+
+def _spearman(a, b):
+    from scipy.stats import spearmanr
+    r, _ = spearmanr(a, b)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Basic interface tests
+# ---------------------------------------------------------------------------
+
+class TestLoadVariancePredictorScoresInterface:
+    def test_returns_none_when_no_columns(self, tmp_path):
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        ml_file = _write_ml_info(tmp_path, pids, {"col": list(range(N))})
+        ion_var = _make_ion_variance(ion_idx, np.ones(len(ion_idx)))
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"], variance_predictor_cols=[],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        assert result is None
+
+    def test_returns_none_when_missing_columns(self, tmp_path):
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        ml_file = _write_ml_info(tmp_path, pids, {"col": list(range(N))})
+        ion_var = _make_ion_variance(ion_idx, np.ones(len(ion_idx)))
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"], variance_predictor_cols=["NoSuchCol"],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        assert result is None
+
+    def test_returns_dict_with_correct_keys(self, tmp_path):
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        col_vals = [float(i) for i in range(N)]
+        ion_var = _make_ion_variance(ion_idx, col_vals)
+        ml_file = _write_ml_info(tmp_path, pids, {"score": col_vals})
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"], variance_predictor_cols=["score"],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        assert result is not None
+        assert set(result.keys()) == set(ion_idx)
+
+    def test_ions_from_same_precursor_get_same_score(self, tmp_path):
+        pids = _precursor_ids()
+        ions = []
+        for pid in pids:
+            ions.append(f"{pid}_FRGION_y3")
+            ions.append(f"{pid}_FRGION_y4")
+        ion_idx = pd.Index(ions)
+        col_vals = [float(i) for i in range(N)]
+        var_vals = [float(i) * 0.1 for i in range(N)]
+        # Each pair of ions from the same precursor gets the same variance
+        ion_var_vals = []
+        for v in var_vals:
+            ion_var_vals.extend([v, v])
+        ion_var = _make_ion_variance(ion_idx, ion_var_vals)
+        ml_file = _write_ml_info(tmp_path, pids, {"score": col_vals})
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"], variance_predictor_cols=["score"],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        assert result is not None
+        for pid in pids:
+            assert result[f"{pid}_FRGION_y3"] == result[f"{pid}_FRGION_y4"]
+
+
+# ---------------------------------------------------------------------------
+# Regression logic tests with controlled distributions
+# ---------------------------------------------------------------------------
+
+class TestRegressionLogic:
+    """Verify the linear-regression approach correctly recovers the
+    relationship between quality metrics and ion variance."""
+
+    def _get_scores(self, tmp_path, columns_dict, variance_predictor_cols,
+                    ion_var_values, ion_med_int_values=None):
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        ml_file = _write_ml_info(tmp_path, pids, columns_dict)
+        ion_var = _make_ion_variance(ion_idx, ion_var_values)
+        ion_med_int = (_make_ion_median_intensity(ion_idx, ion_med_int_values)
+                       if ion_med_int_values is not None else None)
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"],
+            variance_predictor_cols=variance_predictor_cols,
+            ion_index=ion_idx, ion_variance=ion_var,
+            ion_median_intensity=ion_med_int,
+        )
+        assert result is not None
+        return np.array([result[ion] for ion in ion_idx])
+
+    # -- single column, positively correlated with variance ----------------
+
+    def test_single_column_positive_correlation(self, tmp_path):
+        """Column that increases with variance → scores should track variance."""
+        col_vals = [float(i) for i in range(N)]
+        true_var = [float(i) * 0.5 for i in range(N)]  # same direction
+        scores = self._get_scores(tmp_path, {"col": col_vals}, ["col"], true_var)
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95
+
+    # -- single column, negatively correlated with variance ----------------
+
+    def test_single_column_negative_correlation(self, tmp_path):
+        """Column that decreases with variance → negative coefficient,
+        but predicted scores should still track variance."""
+        col_vals = [float(N - 1 - i) for i in range(N)]  # high col = low var
+        true_var = [float(i) * 0.5 for i in range(N)]
+        scores = self._get_scores(tmp_path, {"col": col_vals}, ["col"], true_var)
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95
+
+    # -- two columns in OPPOSITE directions: the key improvement -----------
+
+    def test_two_columns_opposite_direction_both_recovered(self, tmp_path):
+        """One column goes up with variance, the other goes down.
+        The regression should handle both correctly and produce scores
+        that correlate strongly with the true variance."""
+        true_var = [float(i) for i in range(N)]
+        col_up = [float(i) * 2.0 for i in range(N)]             # positive corr
+        col_down = [float(N - 1 - i) * 3.0 for i in range(N)]   # negative corr
+        scores = self._get_scores(
+            tmp_path, {"col_up": col_up, "col_down": col_down},
+            ["col_up", "col_down"], true_var,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95, (
+            f"Expected strong correlation even with opposing columns, got rho={rho:.3f}"
+        )
+
+    # -- magnitude irrelevant (regression handles it) ----------------------
+
+    def test_different_magnitudes(self, tmp_path):
+        """Columns with very different scales should be handled by the
+        standardisation in the regression."""
+        true_var = [float(i) for i in range(N)]
+        col_tiny = [0.001 * i for i in range(N)]
+        col_huge = [1e6 * i for i in range(N)]
+        scores = self._get_scores(
+            tmp_path, {"tiny": col_tiny, "huge": col_huge},
+            ["tiny", "huge"], true_var,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95
+
+    # -- noisy predictor ---------------------------------------------------
+
+    def test_noisy_predictor_still_useful(self, tmp_path):
+        """A clean + noisy column, both in the same direction: combined
+        should still correlate well with true variance."""
+        rng = np.random.RandomState(42)
+        true_var = [float(i) for i in range(N)]
+        col_clean = [float(i) for i in range(N)]
+        col_noisy = [float(i) + rng.normal(0, 5) for i in range(N)]
+        scores = self._get_scores(
+            tmp_path, {"clean": col_clean, "noisy": col_noisy},
+            ["clean", "noisy"], true_var,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.8
+
+    # -- uninformative column gets ~zero weight ----------------------------
+
+    def test_uninformative_column_ignored(self, tmp_path):
+        """A random column uncorrelated with variance should not hurt
+        when combined with a good predictor."""
+        rng = np.random.RandomState(99)
+        true_var = [float(i) for i in range(N)]
+        col_good = [float(i) for i in range(N)]
+        col_random = list(rng.randn(N))
+        scores_combined = self._get_scores(
+            tmp_path, {"good": col_good, "random": col_random},
+            ["good", "random"], true_var,
+        )
+        scores_good_only = self._get_scores(
+            tmp_path, {"good": col_good}, ["good"], true_var,
+        )
+        rho_combined = _spearman(true_var, scores_combined)
+        rho_good = _spearman(true_var, scores_good_only)
+        # Combined should be almost as good as good-only
+        assert rho_combined > 0.9
+        assert rho_combined >= rho_good - 0.1
+
+    # -- three columns, two agree, one opposes -----------------------------
+
+    def test_three_columns_mixed_directions(self, tmp_path):
+        """Two columns positively, one negatively associated with variance.
+        Regression should handle all three correctly."""
+        true_var = [float(i) for i in range(N)]
+        col_up1 = [float(i) for i in range(N)]
+        col_up2 = [float(i) * 3.0 for i in range(N)]
+        col_down = [float(N - 1 - i) for i in range(N)]
+        scores = self._get_scores(
+            tmp_path,
+            {"up1": col_up1, "up2": col_up2, "down": col_down},
+            ["up1", "up2", "down"], true_var,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95
+
+    # -- nonlinear relationship: regression captures the linear component --
+
+    def test_nonlinear_variance_partially_captured(self, tmp_path):
+        """Even if the true relationship is quadratic, the linear model
+        should capture the monotonic trend reasonably well."""
+        true_var = [float(i)**2 for i in range(N)]
+        col_vals = [float(i) for i in range(N)]  # linear predictor
+        scores = self._get_scores(tmp_path, {"col": col_vals}, ["col"], true_var)
+        rho = _spearman(true_var, scores)
+        # Spearman only cares about rank order, so linear model on monotonic
+        # data should give perfect rank correlation
+        assert rho > 0.95
+
+
+# ---------------------------------------------------------------------------
+# Median intensity as built-in predictor
+# ---------------------------------------------------------------------------
+
+class TestMedianIntensityPredictor:
+    """Verify that median intensity is correctly used as a built-in predictor."""
+
+    def _get_scores(self, tmp_path, columns_dict, variance_predictor_cols,
+                    ion_var_values, ion_med_int_values=None):
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        ml_file = _write_ml_info(tmp_path, pids, columns_dict)
+        ion_var = _make_ion_variance(ion_idx, ion_var_values)
+        ion_med_int = (_make_ion_median_intensity(ion_idx, ion_med_int_values)
+                       if ion_med_int_values is not None else None)
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"],
+            variance_predictor_cols=variance_predictor_cols,
+            ion_index=ion_idx, ion_variance=ion_var,
+            ion_median_intensity=ion_med_int,
+        )
+        assert result is not None
+        return np.array([result[ion] for ion in ion_idx])
+
+    def test_intensity_alone_improves_prediction(self, tmp_path):
+        """Adding median intensity as predictor should improve correlation
+        with true variance when intensity is the dominant signal."""
+        rng = np.random.RandomState(7)
+        true_var = np.array([10.0 - 0.4 * i for i in range(N)])
+        intensity = np.array([float(i) for i in range(N)])
+        col_noisy = list(rng.randn(N))
+
+        scores_no_int = self._get_scores(
+            tmp_path, {"noisy": col_noisy}, ["noisy"],
+            true_var, ion_med_int_values=None,
+        )
+        scores_with_int = self._get_scores(
+            tmp_path, {"noisy": col_noisy}, ["noisy"],
+            true_var, ion_med_int_values=intensity,
+        )
+        rho_no_int = abs(_spearman(true_var, scores_no_int))
+        rho_with_int = abs(_spearman(true_var, scores_with_int))
+        assert rho_with_int > rho_no_int + 0.1, (
+            f"Expected intensity to improve prediction: "
+            f"rho_with={rho_with_int:.3f}, rho_without={rho_no_int:.3f}"
+        )
+
+    def test_intensity_negative_coefficient(self, tmp_path):
+        """Higher intensity → lower variance: model should assign negative
+        weight to intensity and scores should track true variance."""
+        intensity = np.array([float(i) for i in range(N)])
+        true_var = np.array([float(N - 1 - i) * 0.5 for i in range(N)])
+        col_vals = list(np.ones(N))  # uninformative quality col
+        scores = self._get_scores(
+            tmp_path, {"flat": col_vals}, ["flat"],
+            true_var, ion_med_int_values=intensity,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.9
+
+    def test_intensity_combined_with_quality_cols(self, tmp_path):
+        """Intensity + opposing quality column: both should be recovered."""
+        intensity = np.array([float(i) for i in range(N)])
+        quality = np.array([float(N - 1 - i) for i in range(N)])
+        true_var = 0.3 * intensity + 0.7 * quality
+        scores = self._get_scores(
+            tmp_path, {"quality": list(quality)}, ["quality"],
+            true_var, ion_med_int_values=intensity,
+        )
+        rho = _spearman(true_var, scores)
+        assert rho > 0.95
+
+    def test_none_intensity_is_equivalent_to_no_intensity(self, tmp_path):
+        """Passing None for ion_median_intensity should give the same results
+        as not passing it at all."""
+        col_vals = [float(i) for i in range(N)]
+        true_var = [float(i) * 0.5 for i in range(N)]
+        scores_none = self._get_scores(
+            tmp_path, {"col": col_vals}, ["col"],
+            true_var, ion_med_int_values=None,
+        )
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        ml_file = _write_ml_info(tmp_path, pids, {"col": col_vals})
+        ion_var = _make_ion_variance(ion_idx, true_var)
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"],
+            variance_predictor_cols=["col"],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        scores_default = np.array([result[ion] for ion in ion_idx])
+        np.testing.assert_array_almost_equal(scores_none, scores_default)
+
+
+# ---------------------------------------------------------------------------
+# _fit_and_predict edge cases
+# ---------------------------------------------------------------------------
+
+class TestFitAndPredictEdgeCases:
+    def test_returns_none_with_too_few_valid_ions(self):
+        prec_features = pd.DataFrame({"col": [1.0, 2.0]}, index=["P1", "P2"])
+        precursor_ids = np.array(["P1", "P2"])
+        ion_index = pd.Index(["P1_FRGION_y1", "P2_FRGION_y1"])
+        ion_var = pd.Series([0.1, 0.2], index=ion_index)
+        result = aq_vp._fit_and_predict(
+            prec_features, ["col"], precursor_ids, ion_index, ion_var
+        )
+        assert result is None
+
+    def test_missing_features_get_median_fallback(self, tmp_path):
+        """Ions whose precursor isn't in the ml_info_table should get the
+        median predicted score instead of NaN."""
+        pids = _precursor_ids()
+        ion_idx = _ion_index(pids)
+        col_vals = [float(i) for i in range(N)]
+        true_var = [float(i) for i in range(N)]
+        # Only write ml_info for half the precursors
+        half_pids = pids[:N // 2]
+        half_cols = col_vals[:N // 2]
+        ml_file = _write_ml_info(tmp_path, half_pids, {"col": half_cols})
+        ion_var = _make_ion_variance(ion_idx, true_var)
+        result = aq_vp.load_variance_predictor_scores(
+            ml_file, ["S1", "S2"], variance_predictor_cols=["col"],
+            ion_index=ion_idx, ion_variance=ion_var,
+        )
+        assert result is not None
+        # All scores should be finite (no NaN)
+        assert all(np.isfinite(v) for v in result.values())
+
+
+# ---------------------------------------------------------------------------
+# Ion split pattern tests
+# ---------------------------------------------------------------------------
+
+class TestIonSplitPattern:
+    def test_splits_frgion(self):
+        parts = aq_vp._ION_SPLIT_PAT.split("PEP1_MOD1_2_FRGION_y3")
+        assert parts[0] == "PEP1_MOD1_2"
+
+    def test_splits_ms1isotopes(self):
+        parts = aq_vp._ION_SPLIT_PAT.split("PEP1_MOD1_2_MS1ISOTOPES_0")
+        assert parts[0] == "PEP1_MOD1_2"
+
+    def test_no_split_for_precursor_ids(self):
+        parts = aq_vp._ION_SPLIT_PAT.split("PEP1_MOD1_2")
+        assert len(parts) == 1
+        assert parts[0] == "PEP1_MOD1_2"


### PR DESCRIPTION
## Summary
- Adds `variance_predictor.py`: a linear regression model that predicts per-ion variance from intensity, used to weight z-score aggregation
- Includes full unit test suite

## Notes
Part of the residual decorrelation PR stack. Stacked on #130.