### PR TITLE
Add intensity summarization module

### DIFF
--- a/alphaquant/diffquant/intensity_summarization.py
+++ b/alphaquant/diffquant/intensity_summarization.py
@@ -1,0 +1,326 @@
+"""Intensity summarization for hierarchical ion trees.
+
+Sums base-ion intensities at specified tree node types before differential
+analysis.  For example, specifying ``["frgion"]`` will sum all individual
+fragment ions under each fragment-ion group into a single intensity per
+replicate, while leaving MS1-isotope and precursor base ions untouched.
+
+When the requested summarization level is above the ion-type level
+(e.g. ``"mod_seq_charge"`` or ``"seq"``), leaves are split by their
+ion-type ancestor so that fragment and MS1 intensities are never mixed.
+"""
+
+import re
+from collections import defaultdict
+
+import anytree
+import numpy as np
+import pandas as pd
+
+from alphaquant.cluster.cluster_ions import REGEX_FRGIONS_ISOTOPES, LEVEL_NAMES
+
+import alphaquant.config.config as aqconfig
+import logging
+
+aqconfig.setup_logging()
+LOGGER = logging.getLogger(__name__)
+
+ION_TYPE_NODES = {"frgion", "ms1_isotopes", "precursor"}
+
+# Appended to an ion_type node name so the result is a valid base-ion name
+# that the downstream tree builder can parse back into the hierarchy.
+_NODE_TYPE_TO_COMPLETION_SUFFIX = {
+    "frgion": "ION_SUM",
+    "ms1_isotopes": "ISOTOPES_SUM",
+    "precursor": "URSOR_SUM",
+}
+
+# When summarising above ion_type level we insert a synthetic path fragment
+# between the higher-level node name and the ion-type suffix.
+_LEVEL_TO_SYNTHETIC_INFIX = {
+    "mod_seq_charge": "_",
+    "mod_seq": "CHARGE_0_",
+    "seq": "SUM_CHARGE_0_",
+}
+
+_ION_TYPE_TO_FULL_SUFFIX = {
+    "frgion": "FRGION_SUM",
+    "ms1_isotopes": "MS1ISOTOPES_SUM",
+    "precursor": "PRECURSOR_SUM",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tree construction (lightweight, from ion-name strings only)
+# ---------------------------------------------------------------------------
+
+def build_tree_from_ion_names(protein_name, ion_names):
+    """Build a hierarchical tree from base-ion name strings.
+
+    Uses the same regex logic as
+    :func:`~alphaquant.cluster.cluster_ions.create_hierarchical_ion_grouping`
+    but operates on plain strings rather than ``DifferentialIon`` objects.
+    """
+    nodes = [
+        anytree.Node(name, type="base", level="base")
+        for name in ion_names
+    ]
+
+    for level_idx, level_patterns in enumerate(REGEX_FRGIONS_ISOTOPES):
+        name2node = {}
+        for pattern, node_type in level_patterns:
+            for node in nodes:
+                m = re.match(pattern, node.name)
+                if m:
+                    matching_name = m.group(1)
+                    if matching_name not in name2node:
+                        name2node[matching_name] = anytree.Node(
+                            matching_name,
+                            type=node_type,
+                            level=LEVEL_NAMES[level_idx],
+                        )
+                    node.parent = name2node[matching_name]
+        if name2node:
+            nodes = list(name2node.values())
+
+    root = anytree.Node(protein_name, type="gene", level="gene")
+    for node in nodes:
+        node.parent = root
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Naming helpers
+# ---------------------------------------------------------------------------
+
+def _make_summarized_name_for_ion_type_node(node):
+    """Parseable summarized name for a node at the ion_type level."""
+    return node.name + _NODE_TYPE_TO_COMPLETION_SUFFIX[node.type]
+
+
+def _make_summarized_name_for_higher_node(parent_node, ion_type):
+    """Parseable summarized name when summarising above ion_type level.
+
+    Inserts a synthetic path fragment so that the downstream tree builder
+    can still parse the resulting name into the full hierarchy.
+    """
+    infix = _LEVEL_TO_SYNTHETIC_INFIX[parent_node.level]
+    suffix = _ION_TYPE_TO_FULL_SUFFIX[ion_type]
+    return parent_node.name + infix + suffix
+
+
+# ---------------------------------------------------------------------------
+# Grouping logic
+# ---------------------------------------------------------------------------
+
+def compute_summarization_groups(pep2prot, ion_names, summarization_nodes):
+    """Determine which base ions to group and what to name the summaries.
+
+    Args:
+        pep2prot: dict mapping ion name -> protein name.
+        ion_names: iterable of all base-ion names present in either condition.
+        summarization_nodes: list of node types to summarize
+            (e.g. ``["frgion"]``).
+
+    Returns:
+        groups: list of ``(new_name, [leaf_ion_names], protein)`` tuples.
+        remaining: set of ion names that stay as individual rows.
+    """
+    if not summarization_nodes:
+        return [], set(ion_names)
+
+    prot2ions = defaultdict(list)
+    for ion in ion_names:
+        prot = pep2prot.get(ion)
+        if prot is not None:
+            prot2ions[prot].append(ion)
+
+    groups = []
+    summarized_ions = set()
+
+    for prot, ions in prot2ions.items():
+        tree = build_tree_from_ion_names(prot, ions)
+
+        for node_type in summarization_nodes:
+            target_nodes = anytree.findall(
+                tree, filter_=lambda n, nt=node_type: n.type == nt
+            )
+
+            for target_node in target_nodes:
+                if node_type in ION_TYPE_NODES:
+                    leaf_names = [
+                        l.name for l in target_node.leaves if l.type == "base"
+                    ]
+                    if leaf_names:
+                        new_name = _make_summarized_name_for_ion_type_node(
+                            target_node
+                        )
+                        groups.append((new_name, leaf_names, prot))
+                        summarized_ions.update(leaf_names)
+                else:
+                    # Above ion_type: split by ion type to avoid mixing
+                    type_to_leaves = defaultdict(list)
+                    for desc in anytree.PreOrderIter(target_node):
+                        if desc.type in ION_TYPE_NODES:
+                            for leaf in desc.leaves:
+                                if leaf.type == "base":
+                                    type_to_leaves[desc.type].append(leaf.name)
+                    for ion_type, leaf_names in type_to_leaves.items():
+                        new_name = _make_summarized_name_for_higher_node(
+                            target_node, ion_type
+                        )
+                        groups.append((new_name, leaf_names, prot))
+                        summarized_ions.update(leaf_names)
+
+    remaining = set(ion_names) - summarized_ions
+    return groups, remaining
+
+
+# ---------------------------------------------------------------------------
+# DataFrame summarization
+# ---------------------------------------------------------------------------
+
+def summarize_condition_df(df, groups, remaining_ions):
+    """Apply summarization to a per-condition dataframe.
+
+    Sums intensities in **linear** space for grouped ions, keeps remaining
+    ions as-is.
+
+    Args:
+        df: DataFrame with log2 intensities, index = quant_id,
+            columns = sample names.
+        groups: list of ``(new_name, [leaf_ion_names], protein)`` tuples.
+        remaining_ions: set of ion names to keep unchanged.
+
+    Returns:
+        Summarized DataFrame (same column layout, modified index).
+    """
+    parts = []
+
+    remaining_in_df = df.index.intersection(remaining_ions)
+    if len(remaining_in_df) > 0:
+        parts.append(df.loc[remaining_in_df])
+
+    for new_name, leaf_names, _prot in groups:
+        present = [ion for ion in leaf_names if ion in df.index]
+        if not present:
+            continue
+        subset = df.loc[present]
+        linear = 2.0 ** subset
+        summed = linear.sum(axis=0)
+        all_nan = subset.isna().all(axis=0)
+        with np.errstate(divide='ignore'):
+            log2_summed = np.log2(summed)
+        log2_summed[all_nan] = np.nan
+        log2_summed.name = new_name
+        parts.append(log2_summed.to_frame().T)
+
+    if not parts:
+        return pd.DataFrame(columns=df.columns)
+
+    return pd.concat(parts)
+
+
+# ---------------------------------------------------------------------------
+# Ion quality filtering per group
+# ---------------------------------------------------------------------------
+
+def _filter_group_ions(leaf_names, df_c1, df_c2):
+    """Select which leaf ions to include in a summarization group.
+
+    Strategy:
+      1. Keep only ions that have values in ALL replicates of BOTH conditions.
+      2. If no ion qualifies, pick the single ion with the most non-NaN values
+         across both conditions.
+
+    Returns:
+        Filtered list of ion names.
+    """
+    present_c1 = [ion for ion in leaf_names if ion in df_c1.index]
+    present_c2 = [ion for ion in leaf_names if ion in df_c2.index]
+    present_both = set(present_c1) & set(present_c2)
+
+    if not present_both:
+        all_present = set(present_c1) | set(present_c2)
+        if not all_present:
+            return []
+        best_ion = max(all_present, key=lambda ion: (
+            df_c1.loc[ion].notna().sum() if ion in df_c1.index else 0
+        ) + (
+            df_c2.loc[ion].notna().sum() if ion in df_c2.index else 0
+        ))
+        return [best_ion]
+
+    n_cols_c1 = df_c1.shape[1]
+    n_cols_c2 = df_c2.shape[1]
+
+    complete = [
+        ion for ion in present_both
+        if df_c1.loc[ion].notna().sum() == n_cols_c1
+        and df_c2.loc[ion].notna().sum() == n_cols_c2
+    ]
+
+    if complete:
+        return complete
+
+    best_ion = max(present_both, key=lambda ion:
+        df_c1.loc[ion].notna().sum() + df_c2.loc[ion].notna().sum()
+    )
+    return [best_ion]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def apply_summarization(df_c1, df_c2, pep2prot, summarization_nodes):
+    """Summarize ion intensities at specified tree levels.
+
+    This is the main entry point called from
+    :func:`~alphaquant.diffquant.condpair_analysis.analyze_condpair`.
+
+    Args:
+        df_c1: Per-condition DataFrame for condition 1 (log2 intensities).
+        df_c2: Per-condition DataFrame for condition 2 (log2 intensities).
+        pep2prot: dict mapping ion name -> protein name.
+        summarization_nodes: list of node types to summarize
+            (e.g. ``["frgion"]``).
+
+    Returns:
+        ``(df_c1_new, df_c2_new, pep2prot_new)``
+    """
+    all_ions = set(df_c1.index) | set(df_c2.index)
+    groups, remaining = compute_summarization_groups(
+        pep2prot, all_ions, summarization_nodes
+    )
+
+    if not groups:
+        return df_c1, df_c2, pep2prot
+
+    filtered_groups = []
+    for new_name, leaf_names, prot in groups:
+        selected = _filter_group_ions(leaf_names, df_c1, df_c2)
+        if selected:
+            filtered_groups.append((new_name, selected, prot))
+
+    if not filtered_groups:
+        return df_c1, df_c2, pep2prot
+
+    df_c1_new = summarize_condition_df(df_c1, filtered_groups, remaining)
+    df_c2_new = summarize_condition_df(df_c2, filtered_groups, remaining)
+
+    pep2prot_new = {ion: pep2prot[ion] for ion in remaining if ion in pep2prot}
+    for new_name, _leaves, prot in filtered_groups:
+        pep2prot_new[new_name] = prot
+
+    LOGGER.info(
+        "Summarization at %s: %d base ions -> %d entries "
+        "(%d summarized groups, %d unchanged)",
+        summarization_nodes,
+        len(all_ions),
+        len(remaining) + len(filtered_groups),
+        len(filtered_groups),
+        len(remaining),
+    )
+
+    return df_c1_new, df_c2_new, pep2prot_new

--- a/tests/unit_tests/test_intensity_summarization.py
+++ b/tests/unit_tests/test_intensity_summarization.py
@@ -1,0 +1,270 @@
+import numpy as np
+import pandas as pd
+import pytest
+import re
+
+import alphaquant.diffquant.intensity_summarization as aq_summ
+from alphaquant.cluster.cluster_ions import REGEX_FRGIONS_ISOTOPES
+
+
+# ---------------------------------------------------------------------------
+# Helpers — realistic ion names following the SEQ_..._MOD_..._CHARGE_... pattern
+# ---------------------------------------------------------------------------
+
+PROT = "PROT1"
+
+# Precursor 1: charge 2
+FRGION_Y3 = "SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_y3_noloss_1"
+FRGION_Y4 = "SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_y4_noloss_1"
+MS1ISO_0 = "SEQ_PEP1_MOD_MOD1_CHARGE_2_MS1ISOTOPES_0"
+MS1ISO_1 = "SEQ_PEP1_MOD_MOD1_CHARGE_2_MS1ISOTOPES_1"
+PREC_2 = "SEQ_PEP1_MOD_MOD1_CHARGE_2_PRECURSOR_2"
+
+# Precursor 2: charge 3 (same peptide, different charge)
+FRGION_C3_Y5 = "SEQ_PEP1_MOD_MOD1_CHARGE_3_FRGION_y5_noloss_1"
+
+ALL_IONS = [FRGION_Y3, FRGION_Y4, MS1ISO_0, MS1ISO_1, PREC_2, FRGION_C3_Y5]
+PEP2PROT = {ion: PROT for ion in ALL_IONS}
+
+
+def _make_df(ions, values_per_sample):
+    """Build a log2-intensity DataFrame from a dict {sample: [values_per_ion]}."""
+    return pd.DataFrame(values_per_sample, index=ions)
+
+
+# ---------------------------------------------------------------------------
+# Tree building
+# ---------------------------------------------------------------------------
+
+class TestBuildTreeFromIonNames:
+    def test_gene_root(self):
+        tree = aq_summ.build_tree_from_ion_names(PROT, ALL_IONS)
+        assert tree.name == PROT
+        assert tree.type == "gene"
+
+    def test_leaf_count(self):
+        tree = aq_summ.build_tree_from_ion_names(PROT, ALL_IONS)
+        assert len(tree.leaves) == len(ALL_IONS)
+
+    def test_frgion_nodes_exist(self):
+        tree = aq_summ.build_tree_from_ion_names(PROT, ALL_IONS)
+        import anytree
+        frgion_nodes = anytree.findall(tree, filter_=lambda n: n.type == "frgion")
+        assert len(frgion_nodes) == 2  # one per charge state
+
+    def test_ms1_nodes_exist(self):
+        tree = aq_summ.build_tree_from_ion_names(PROT, ALL_IONS)
+        import anytree
+        ms1_nodes = anytree.findall(tree, filter_=lambda n: n.type == "ms1_isotopes")
+        assert len(ms1_nodes) == 1
+
+    def test_single_ion(self):
+        tree = aq_summ.build_tree_from_ion_names(PROT, [FRGION_Y3])
+        assert len(tree.leaves) == 1
+
+
+# ---------------------------------------------------------------------------
+# Grouping logic
+# ---------------------------------------------------------------------------
+
+class TestComputeSummarizationGroups:
+    def test_empty_summarization_nodes(self):
+        groups, remaining = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, [])
+        assert groups == []
+        assert remaining == set(ALL_IONS)
+
+    def test_frgion_only(self):
+        groups, remaining = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, ["frgion"])
+        summarized_leaves = set()
+        for _name, leaves, _prot in groups:
+            summarized_leaves.update(leaves)
+        # All FRGION base ions should be summarized
+        assert FRGION_Y3 in summarized_leaves
+        assert FRGION_Y4 in summarized_leaves
+        assert FRGION_C3_Y5 in summarized_leaves
+        # MS1 and precursor should remain
+        assert MS1ISO_0 in remaining
+        assert MS1ISO_1 in remaining
+        assert PREC_2 in remaining
+        # Two groups: one per charge state
+        assert len(groups) == 2
+
+    def test_ms1_only(self):
+        groups, remaining = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, ["ms1_isotopes"])
+        assert len(groups) == 1
+        assert FRGION_Y3 in remaining
+        assert FRGION_Y4 in remaining
+
+    def test_frgion_and_ms1(self):
+        groups, remaining = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, ["frgion", "ms1_isotopes"])
+        summarized_leaves = set()
+        for _name, leaves, _prot in groups:
+            summarized_leaves.update(leaves)
+        assert FRGION_Y3 in summarized_leaves
+        assert MS1ISO_0 in summarized_leaves
+        # Only precursor should remain
+        assert remaining == {PREC_2}
+
+    def test_mod_seq_charge_splits_by_ion_type(self):
+        groups, remaining = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, ["mod_seq_charge"])
+        # Two mod_seq_charge nodes (charge 2 and charge 3).
+        # Charge 2 has frgion + ms1 + precursor -> 3 groups.
+        # Charge 3 has only frgion -> 1 group.
+        assert len(groups) == 4
+        assert len(remaining) == 0
+
+
+# ---------------------------------------------------------------------------
+# Naming — summarized names must be parseable by downstream tree builder
+# ---------------------------------------------------------------------------
+
+class TestSummarizedNamesParseable:
+    """Verify that summarized ion names are matched by the REGEX_FRGIONS_ISOTOPES
+    patterns, so the downstream tree builder can incorporate them."""
+
+    def _level0_matches(self, name):
+        for pattern, _node_type in REGEX_FRGIONS_ISOTOPES[0]:
+            if re.match(pattern, name):
+                return True
+        return False
+
+    def test_frgion_sum_name_parseable(self):
+        groups, _ = aq_summ.compute_summarization_groups(PEP2PROT, [FRGION_Y3, FRGION_Y4], ["frgion"])
+        for name, _leaves, _prot in groups:
+            assert self._level0_matches(name), f"'{name}' not parseable by level-0 regex"
+
+    def test_ms1_sum_name_parseable(self):
+        groups, _ = aq_summ.compute_summarization_groups(PEP2PROT, [MS1ISO_0, MS1ISO_1], ["ms1_isotopes"])
+        for name, _leaves, _prot in groups:
+            assert self._level0_matches(name), f"'{name}' not parseable by level-0 regex"
+
+    def test_mod_seq_charge_sum_names_parseable(self):
+        groups, _ = aq_summ.compute_summarization_groups(PEP2PROT, ALL_IONS, ["mod_seq_charge"])
+        for name, _leaves, _prot in groups:
+            assert self._level0_matches(name), f"'{name}' not parseable by level-0 regex"
+
+
+# ---------------------------------------------------------------------------
+# DataFrame summarization
+# ---------------------------------------------------------------------------
+
+class TestSummarizeConditionDf:
+    @pytest.fixture
+    def simple_df(self):
+        return _make_df(
+            [FRGION_Y3, FRGION_Y4, MS1ISO_0],
+            {"s1": np.log2([100.0, 50.0, 500.0]), "s2": np.log2([200.0, 80.0, 600.0])},
+        )
+
+    def test_frgion_sum_values(self, simple_df):
+        groups = [
+            ("SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_SUM", [FRGION_Y3, FRGION_Y4], PROT),
+        ]
+        remaining = {MS1ISO_0}
+        result = aq_summ.summarize_condition_df(simple_df, groups, remaining)
+
+        assert "SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_SUM" in result.index
+        assert MS1ISO_0 in result.index
+        # sum(100+50)=150 for s1
+        assert np.isclose(result.loc["SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_SUM", "s1"], np.log2(150.0))
+        # sum(200+80)=280 for s2
+        assert np.isclose(result.loc["SEQ_PEP1_MOD_MOD1_CHARGE_2_FRGION_SUM", "s2"], np.log2(280.0))
+
+    def test_ms1_unchanged(self, simple_df):
+        groups = [
+            ("SUMMED", [FRGION_Y3, FRGION_Y4], PROT),
+        ]
+        remaining = {MS1ISO_0}
+        result = aq_summ.summarize_condition_df(simple_df, groups, remaining)
+
+        assert np.isclose(result.loc[MS1ISO_0, "s1"], simple_df.loc[MS1ISO_0, "s1"])
+
+    def test_all_nan_stays_nan(self):
+        df = _make_df(
+            [FRGION_Y3, FRGION_Y4],
+            {"s1": [np.nan, np.nan], "s2": np.log2([100.0, 50.0])},
+        )
+        groups = [("SUM", [FRGION_Y3, FRGION_Y4], PROT)]
+        result = aq_summ.summarize_condition_df(df, groups, set())
+
+        assert np.isnan(result.loc["SUM", "s1"])
+        assert np.isclose(result.loc["SUM", "s2"], np.log2(150.0))
+
+    def test_partial_nan_sums_available(self):
+        df = _make_df(
+            [FRGION_Y3, FRGION_Y4],
+            {"s1": [np.log2(100.0), np.nan], "s2": np.log2([100.0, 50.0])},
+        )
+        groups = [("SUM", [FRGION_Y3, FRGION_Y4], PROT)]
+        result = aq_summ.summarize_condition_df(df, groups, set())
+
+        # Only y3 contributes in s1
+        assert np.isclose(result.loc["SUM", "s1"], np.log2(100.0))
+
+    def test_empty_group_skipped(self):
+        df = _make_df([MS1ISO_0], {"s1": [np.log2(500.0)]})
+        groups = [("SUM", [FRGION_Y3, FRGION_Y4], PROT)]  # neither present in df
+        remaining = {MS1ISO_0}
+        result = aq_summ.summarize_condition_df(df, groups, remaining)
+
+        assert len(result) == 1
+        assert MS1ISO_0 in result.index
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: apply_summarization
+# ---------------------------------------------------------------------------
+
+class TestApplySummarization:
+    @pytest.fixture
+    def condition_dfs(self):
+        ions = [FRGION_Y3, FRGION_Y4, MS1ISO_0, MS1ISO_1, PREC_2]
+        df_c1 = _make_df(ions, {
+            "s1": np.log2([100.0, 50.0, 500.0, 200.0, 800.0]),
+            "s2": np.log2([120.0, 60.0, 520.0, 210.0, 820.0]),
+        })
+        df_c2 = _make_df(ions, {
+            "s3": np.log2([90.0, 40.0, 480.0, 190.0, 790.0]),
+            "s4": np.log2([110.0, 55.0, 510.0, 205.0, 810.0]),
+        })
+        pep2prot = {ion: PROT for ion in ions}
+        return df_c1, df_c2, pep2prot
+
+    def test_no_summarization(self, condition_dfs):
+        df_c1, df_c2, pep2prot = condition_dfs
+        r1, r2, rp = aq_summ.apply_summarization(df_c1, df_c2, pep2prot, [])
+        assert r1 is df_c1  # unchanged object
+        assert r2 is df_c2
+
+    def test_frgion_reduces_row_count(self, condition_dfs):
+        df_c1, df_c2, pep2prot = condition_dfs
+        r1, r2, rp = aq_summ.apply_summarization(df_c1, df_c2, pep2prot, ["frgion"])
+        # 5 ions -> 1 frgion sum + 2 ms1 + 1 precursor = 4
+        assert len(r1) == 4
+        assert len(r2) == 4
+
+    def test_pep2prot_updated(self, condition_dfs):
+        df_c1, df_c2, pep2prot = condition_dfs
+        _, _, rp = aq_summ.apply_summarization(df_c1, df_c2, pep2prot, ["frgion"])
+        # Every row in the result should have a protein mapping
+        for ion in set(rp.keys()):
+            assert rp[ion] == PROT
+
+    def test_frgion_and_ms1(self, condition_dfs):
+        df_c1, df_c2, pep2prot = condition_dfs
+        r1, r2, rp = aq_summ.apply_summarization(df_c1, df_c2, pep2prot, ["frgion", "ms1_isotopes"])
+        # 1 frgion sum + 1 ms1 sum + 1 precursor = 3
+        assert len(r1) == 3
+
+    def test_asymmetric_conditions(self):
+        """Ion present in c1 but not c2 — group is skipped in c2."""
+        df_c1 = _make_df([FRGION_Y3, FRGION_Y4], {"s1": np.log2([100.0, 50.0])})
+        df_c2 = _make_df([FRGION_Y3], {"s2": np.log2([90.0])})
+        pep2prot = {FRGION_Y3: PROT, FRGION_Y4: PROT}
+
+        r1, r2, rp = aq_summ.apply_summarization(df_c1, df_c2, pep2prot, ["frgion"])
+        # c1: y3+y4 summed; c2: only y3 present -> partial sum
+        assert len(r1) == 1
+        assert len(r2) == 1
+        assert np.isclose(r1.iloc[0, 0], np.log2(150.0))
+        assert np.isclose(r2.iloc[0, 0], np.log2(90.0))


### PR DESCRIPTION
## Summary
- Adds `intensity_summarization.py`: implements alternative intensity-based summarization approaches for aggregating ions to peptide/protein level
- Includes full unit test suite

## Notes
Part of the residual decorrelation PR stack. Stacked on #131.