### PR TITLE
Add ICC correction module

### DIFF
--- a/alphaquant/cluster/icc_correction.py
+++ b/alphaquant/cluster/icc_correction.py
@@ -1,0 +1,521 @@
+"""Data-driven ICC (intraclass correlation) correction for Stouffer z-value aggregation.
+
+Estimates a global ICC at every aggregation level of the protein tree and
+annotates each node with an ``icc_correction`` attribute so that
+``aggregate_node_properties`` can apply a design-effect correction.
+
+The tree levels processed (bottom-to-top):
+  - ``frgion``: correlation among fragment ions within the same precursor
+  - ``ms1_isotopes``: correlation among MS1 isotopes within the same precursor
+  - ``mod_seq_charge``: correlation among ion families within the same precursor
+  - ``mod_seq``: correlation among charge states within the same modified peptide
+  - ``seq``: correlation among modification variants within the same sequence
+  - ``gene``: correlation among peptides within the same protein
+
+A protein contributes to the null distribution only when *both* its
+protein-level p-value and the p-values of its individual group nodes
+exceed the significance threshold.  This two-level filter ensures the ICC
+is estimated purely from technical noise, free of biological signal at
+any level.
+
+The resulting null-median ICC is applied uniformly to all proteins.
+Per-protein estimation is deliberately avoided: the ICC captures a
+property of the *measurement* (shared chromatographic / detector effects),
+not of the individual protein, and per-protein estimates are too noisy
+to be reliable given typical group sizes.
+
+Processing proceeds bottom-to-top: after each level's ICC is estimated
+and applied, trees are re-aggregated so that higher levels see the
+corrected z-values from below.
+"""
+
+import anytree
+import numpy as np
+import matplotlib.pyplot as plt
+
+import alphaquant.cluster.cluster_utils as aqcluster_utils
+
+import alphaquant.config.config as aqconfig
+import alphaquant.config.variables as aqvariables
+import logging
+aqconfig.setup_logging()
+LOGGER = logging.getLogger(__name__)
+
+# Node types that receive ICC correction, ordered bottom-to-top.
+_ICC_NODE_TYPES = ("frgion", "ms1_isotopes", "mod_seq_charge", "mod_seq", "seq", "gene")
+
+_MIN_GROUPS = 3   # minimum number of group nodes for a reliable ICC estimate
+_MIN_IONS = 6     # minimum total number of child items across those groups
+
+# Null protein selection threshold is read at runtime from
+# aqvariables.ICC_NULL_PVAL_THRESHOLD (default 0.1, configurable via
+# run_pipeline icc_null_pval_threshold argument).
+
+_N_PERMUTATIONS = 3
+
+# Gene-level subsampled estimation: each draw picks a random subset of
+# null proteins and computes ICC treating each protein as a group.
+_GENE_SUBSAMPLE_SIZE = 5
+_GENE_N_DRAWS = 500
+
+_NODE_TYPE_LABELS = {
+    "frgion":         "Fragment ion",
+    "ms1_isotopes":   "MS1 isotope",
+    "mod_seq_charge": "Ion family",
+    "mod_seq":        "Precursor",
+    "seq":            "Mod. peptide",
+    "gene":           "Peptide",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def estimate_and_apply_icc_correction(protnodes, runtime_plots=False, aggregation_mode="stouffer_decorrelation"):
+    """Estimate a global ICC at every tree level, apply uniformly, and re-aggregate.
+
+    Processes levels bottom-to-top.  After each level's ICC is estimated and
+    assigned, all trees are re-aggregated so that the next (higher) level
+    sees corrected z-values from below.
+
+    Args:
+        protnodes: list of protein root nodes (anytree.Node)
+        runtime_plots: if True, show ICC distribution plots for all levels
+        aggregation_mode: z-value combination strategy forwarded to re-aggregation
+    """
+    if not protnodes:
+        return
+
+    all_level_results = {}
+
+    for node_type in _ICC_NODE_TYPES:
+        if not _has_node_type(protnodes, node_type):
+            continue
+
+        LOGGER.info(f"ICC correction: estimating for node type '{node_type}'")
+
+        if node_type == "gene":
+            null_iccs, perm_iccs, icc_median = _estimate_gene_level_icc(protnodes)
+        else:
+            null_iccs, perm_iccs, icc_median = _estimate_null_icc_distribution(
+                protnodes, node_type
+            )
+
+        n_annotated = _assign_icc_to_all_proteins(protnodes, node_type, icc_median)
+
+        obs_med = float(np.median(null_iccs)) if null_iccs else 0.0
+        perm_med = float(np.median(perm_iccs)) if perm_iccs else 0.0
+        LOGGER.info(
+            f"ICC correction ({node_type}): applied={icc_median:.4f} "
+            f"(obs={obs_med:.4f} - perm={perm_med:.4f}), "
+            f"n_null={len(null_iccs)}, n_perm={len(perm_iccs)}, "
+            f"n_annotated={n_annotated}"
+        )
+
+        all_level_results[node_type] = (null_iccs, perm_iccs, icc_median)
+
+        _re_aggregate_trees(protnodes, aggregation_mode=aggregation_mode)
+
+    if runtime_plots and all_level_results:
+        _plot_icc_distributions_all_levels(all_level_results)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _has_node_type(protnodes, node_type):
+    """Return True if at least one protein tree contains a node of *node_type*."""
+    for prot in protnodes:
+        matches = anytree.search.findall(
+            prot, filter_=lambda n: n.type == node_type
+        )
+        if matches:
+            return True
+    return False
+
+
+def _estimate_null_icc_distribution(protnodes, node_type):
+    """Compute observed and permutation-based ICC for each null protein.
+
+    A protein qualifies as null only when *both*:
+      - its protein-level p_val > aqvariables.ICC_NULL_PVAL_THRESHOLD, *and*
+      - only group nodes whose own p_val > threshold are used.
+
+    Returns:
+        (null_iccs, permutation_iccs, icc_median).
+        If no null proteins qualify, returns ([], [], 0.0).
+    """
+    null_iccs = []
+    null_group_zvals_list = []
+
+    pval_threshold = aqvariables.get_icc_null_pval_threshold(node_type)
+    for prot in protnodes:
+        if not hasattr(prot, "p_val"):
+            continue
+        if prot.p_val <= pval_threshold:
+            continue
+
+        group_zvals = _collect_group_zvals(prot, node_type, node_p_val_threshold=pval_threshold)
+        if not group_zvals:
+            continue
+
+        icc = _compute_icc_from_groups(group_zvals)
+        if icc is not None:
+            null_iccs.append(icc)
+            null_group_zvals_list.append(group_zvals)
+
+    if len(null_iccs) == 0:
+        LOGGER.warning(
+            f"ICC correction ({node_type}): no null proteins qualified; "
+            "falling back to icc_median=0.0"
+        )
+        return [], [], 0.0
+
+    permutation_iccs = _compute_permutation_null(null_group_zvals_list)
+
+    icc_median = _null_normalized_icc(null_iccs, permutation_iccs)
+    return null_iccs, permutation_iccs, icc_median
+
+
+def _estimate_gene_level_icc(protnodes, seed=42):
+    """Estimate ICC at the protein (gene) level using subsampled estimation.
+
+    Since each protein has exactly one gene node, per-protein ICC is
+    undefined.  Instead, we subsample groups of null proteins and compute
+    ICC treating each protein as a group with its peptide z-values as items.
+
+    The permutation null shuffles all z-values across proteins (destroying
+    the protein-level grouping) and repeats the same subsampled estimation.
+
+    Returns:
+        (null_iccs, permutation_iccs, icc_median).
+    """
+    protein_groups = []
+    gene_threshold = aqvariables.get_icc_null_pval_threshold("gene")
+    for prot in protnodes:
+        if not hasattr(prot, "p_val") or prot.p_val <= gene_threshold:
+            continue
+        children_zvals = [c.z_val for c in prot.children if hasattr(c, "z_val")]
+        if len(children_zvals) >= 2:
+            protein_groups.append(np.array(children_zvals))
+
+    if len(protein_groups) < _GENE_SUBSAMPLE_SIZE:
+        LOGGER.warning(
+            f"ICC correction (gene): only {len(protein_groups)} null proteins "
+            f"with ≥2 peptides (need {_GENE_SUBSAMPLE_SIZE}); falling back to 0.0"
+        )
+        return [], [], 0.0
+
+    rng = np.random.RandomState(seed)
+    null_iccs = _subsampled_icc(protein_groups, rng)
+
+    sizes = [len(g) for g in protein_groups]
+    pooled = np.concatenate(protein_groups)
+    rng_perm = np.random.RandomState(seed + 1)
+    rng_perm.shuffle(pooled)
+    shuffled_groups = []
+    offset = 0
+    for s in sizes:
+        shuffled_groups.append(pooled[offset:offset + s].copy())
+        offset += s
+    perm_iccs = _subsampled_icc(shuffled_groups, np.random.RandomState(seed))
+
+    if not null_iccs:
+        LOGGER.warning("ICC correction (gene): no valid subsamples; falling back to 0.0")
+        return [], [], 0.0
+
+    icc_median = _null_normalized_icc(null_iccs, perm_iccs)
+    return null_iccs, perm_iccs, icc_median
+
+
+def _subsampled_icc(protein_groups, rng,
+                    subset_size=_GENE_SUBSAMPLE_SIZE,
+                    n_draws=_GENE_N_DRAWS):
+    """Compute ICC on random subsets of protein groups.
+
+    Each draw selects *subset_size* proteins, treats each as a group
+    (with its peptide z-values as items), and computes one ICC value.
+    """
+    iccs = []
+    n_proteins = len(protein_groups)
+    for _ in range(n_draws):
+        indices = rng.choice(n_proteins, size=subset_size, replace=False)
+        group_zvals = [protein_groups[i] for i in indices]
+        icc = _compute_icc_from_groups(group_zvals)
+        if icc is not None:
+            iccs.append(icc)
+    return iccs
+
+
+def _compute_permutation_null(group_zvals_list, n_permutations=_N_PERMUTATIONS, seed=42):
+    """Compute ICC on shuffled data to establish a permutation baseline.
+
+    For each protein's grouped z-values, all values are pooled and randomly
+    reassigned to groups of the original sizes.  This destroys any real
+    intra-group correlation, so the resulting ICC distribution reflects pure
+    sampling noise.
+    """
+    rng = np.random.RandomState(seed)
+    perm_iccs = []
+
+    for group_zvals in group_zvals_list:
+        sizes = [len(g) for g in group_zvals]
+        pooled = np.concatenate(group_zvals)
+
+        for _ in range(n_permutations):
+            rng.shuffle(pooled)
+            shuffled_groups = []
+            offset = 0
+            for s in sizes:
+                shuffled_groups.append(pooled[offset:offset + s].copy())
+                offset += s
+
+            icc = _compute_icc_from_groups(shuffled_groups)
+            if icc is not None:
+                perm_iccs.append(icc)
+
+    return perm_iccs
+
+
+def _null_normalized_icc(null_iccs, perm_iccs):
+    """Return the null-normalized ICC: median(observed) - median(shuffled), clamped to ≥0."""
+    obs_med = float(np.median(null_iccs))
+    perm_med = float(np.median(perm_iccs)) if len(perm_iccs) > 0 else 0.0
+    return max(0.0, obs_med - perm_med)
+
+
+def _assign_icc_to_all_proteins(protnodes, node_type, icc_median):
+    """Assign the global null-median ICC uniformly to every node of *node_type*.
+
+    Returns:
+        Number of nodes annotated.
+    """
+    n_annotated = 0
+    for prot in protnodes:
+        target_nodes = anytree.search.findall(
+            prot, filter_=lambda n: n.type == node_type
+        )
+        for node in target_nodes:
+            node.icc_correction = icc_median
+            n_annotated += 1
+    return n_annotated
+
+
+def _collect_group_zvals(protein_node, node_type, node_p_val_threshold=None):
+    """Extract grouped z-values from a protein tree.
+
+    For each node of *node_type*, collects the z-values of its immediate
+    children.  At the ion-type level (frgion, ms1_isotopes) the children
+    are base ions; at higher levels they are aggregated child nodes.
+
+    Returns:
+        list[np.ndarray]: One array of child z-values per qualifying group
+            node, or an empty list if insufficient data.
+    """
+    group_nodes = anytree.search.findall(
+        protein_node, filter_=lambda n: n.type == node_type
+    )
+    if not group_nodes:
+        return []
+
+    if node_p_val_threshold is not None:
+        group_nodes = [
+            n for n in group_nodes
+            if hasattr(n, "p_val") and n.p_val > node_p_val_threshold
+        ]
+
+    group_zvals = []
+    for gnode in group_nodes:
+        children = [
+            c for c in gnode.children
+            if hasattr(c, "z_val")
+        ]
+        if children:
+            group_zvals.append(
+                np.array([c.z_val for c in children])
+            )
+
+    n_groups = len(group_zvals)
+    if n_groups < _MIN_GROUPS:
+        return []
+
+    n_items = sum(len(g) for g in group_zvals)
+    if n_items < _MIN_IONS:
+        return []
+
+    return group_zvals
+
+
+def _compute_icc_from_groups(group_zvals):
+    """Compute one-way random-effects ICC from pre-collected grouped z-values.
+
+    Returns:
+        ICC (float) or None if degenerate.
+    """
+    n_groups = len(group_zvals)
+    if n_groups < _MIN_GROUPS:
+        return None
+
+    all_vals = np.concatenate(group_zvals)
+    n_items = len(all_vals)
+    if n_items < _MIN_IONS:
+        return None
+
+    grand_mean = all_vals.mean()
+
+    ss_within = 0.0
+    group_sizes = np.empty(n_groups, dtype=int)
+    group_means = np.empty(n_groups)
+    for i, gv in enumerate(group_zvals):
+        gm = gv.mean()
+        group_means[i] = gm
+        group_sizes[i] = len(gv)
+        ss_within += np.sum((gv - gm) ** 2)
+
+    df_within = n_items - n_groups
+    if df_within < 1:
+        return None
+    sigma2_residual = ss_within / df_within
+
+    expanded_group_means = np.repeat(group_means, group_sizes)
+    ss_between = np.sum((expanded_group_means - grand_mean) ** 2)
+    df_between = n_groups - 1
+    ms_between = ss_between / df_between
+
+    n0 = (n_items - np.sum(group_sizes ** 2) / n_items) / df_between
+    if n0 < 1e-15:
+        return None
+
+    sigma2_group = (ms_between - sigma2_residual) / n0
+    sigma2_group = max(sigma2_group, 0.0)
+
+    total = sigma2_group + sigma2_residual
+    if total < 1e-15:
+        return None
+
+    return sigma2_group / total
+
+
+def _compute_icc_from_tree(protein_node, node_type, node_p_val_threshold=None):
+    """Convenience wrapper: extract groups from tree, then compute ICC."""
+    group_zvals = _collect_group_zvals(protein_node, node_type, node_p_val_threshold)
+    if not group_zvals:
+        return None
+    return _compute_icc_from_groups(group_zvals)
+
+
+def _re_aggregate_trees(protnodes, aggregation_mode="stouffer_decorrelation"):
+    """Re-aggregate all protein trees bottom-to-top after ICC annotation.
+
+    Walks every tree from leaves upward, re-computing z-values and p-values
+    at each level so that the newly annotated ``icc_correction`` attributes
+    take effect.
+    """
+    for prot in protnodes:
+        for level_nodes in aqcluster_utils.iterate_through_tree_levels_bottom_to_top(prot):
+            node_types = list(set(node.type for node in level_nodes))
+            if node_types == ["base"]:
+                continue
+            for node in level_nodes:
+                if node.children:
+                    aqcluster_utils.aggregate_node_properties(
+                        node, only_use_mainclust=True, peptide_outlier_filtering=False,
+                        aggregation_mode=aggregation_mode
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+def _plot_icc_distributions_all_levels(all_level_results):
+    """Multi-row figure with histogram + CDF per level.
+
+    Each row corresponds to one tree level.  Left panel shows histograms of
+    observed-null and permutation-null ICC distributions; right panel shows
+    cumulative distribution functions.  A vertical line marks the applied
+    median ICC.
+
+    Args:
+        all_level_results: dict mapping node_type →
+            (null_iccs, perm_iccs, icc_median).
+    """
+    ordered_types = [nt for nt in _ICC_NODE_TYPES if nt in all_level_results]
+    display_order = list(reversed(ordered_types))
+    n_levels = len(display_order)
+    if n_levels == 0:
+        return
+
+    fig, axes = plt.subplots(n_levels, 2, figsize=(7.5, 1.8 * n_levels),
+                             squeeze=False)
+    fig.subplots_adjust(hspace=0.65, wspace=0.35, top=0.96, bottom=0.06,
+                        left=0.12, right=0.98)
+
+    color_obs = "#4C72B0"
+    color_perm = "#DD8452"
+    bins = np.linspace(0, 1, 40)
+
+    for row, node_type in enumerate(display_order):
+        null_iccs, perm_iccs, icc_median = all_level_results[node_type]
+        ax_hist, ax_cdf = axes[row]
+        label = _NODE_TYPE_LABELS.get(node_type, node_type)
+
+        legend_handles = []
+
+        if len(perm_iccs) > 0:
+            perm_med = float(np.median(perm_iccs))
+            ax_hist.hist(perm_iccs, bins=bins, alpha=0.45, color=color_perm,
+                         edgecolor="none")
+            s = np.sort(perm_iccs)
+            ax_cdf.plot(s, np.arange(1, len(s) + 1) / len(s), color=color_perm)
+            legend_handles.append(
+                plt.matplotlib.patches.Patch(
+                    facecolor=color_perm, alpha=0.6,
+                    label=f"shuffled (med={perm_med:.2f})")
+            )
+
+        if len(null_iccs) > 0:
+            obs_med = float(np.median(null_iccs))
+            ax_hist.hist(null_iccs, bins=bins, alpha=0.45, color=color_obs,
+                         edgecolor="none")
+            s = np.sort(null_iccs)
+            ax_cdf.plot(s, np.arange(1, len(s) + 1) / len(s), color=color_obs)
+            legend_handles.append(
+                plt.matplotlib.patches.Patch(
+                    facecolor=color_obs, alpha=0.6,
+                    label=f"observed (med={obs_med:.2f})")
+            )
+
+        ax_cdf.axvline(0.5, color="gray", linestyle=":", linewidth=0.6)
+
+        for ax in (ax_hist, ax_cdf):
+            ax.set_xlim(-0.05, 1.05)
+            ax.tick_params(axis='both', which='both', length=3, pad=2)
+
+        ax_hist.set_ylabel("count")
+        ax_cdf.set_ylabel("cum. fraction")
+        ax_cdf.set_ylim(-0.02, 1.02)
+        ax_cdf.set_yticks([0.0, 0.5, 1.0])
+
+        if row == n_levels - 1:
+            ax_hist.set_xlabel("ICC")
+            ax_cdf.set_xlabel("ICC")
+        else:
+            ax_hist.set_xticklabels([])
+            ax_cdf.set_xticklabels([])
+
+        ax_hist.legend(handles=legend_handles, loc='upper right',
+                       fontsize=6, frameon=False, handlelength=1,
+                       handletextpad=0.4, borderpad=0.2)
+
+        pos_l = ax_hist.get_position()
+        pos_r = ax_cdf.get_position()
+        x_mid = (pos_l.x0 + pos_r.x1) / 2
+        fig.text(x_mid, pos_l.y1 + 0.008, label,
+                 ha='center', va='bottom', fontsize=10, fontweight='bold')
+
+    fig.suptitle("ICC distributions across tree levels", fontsize=12,
+                 fontweight='bold', y=0.995)
+    plt.show()

--- a/tests/unit_tests/test_icc_correction.py
+++ b/tests/unit_tests/test_icc_correction.py
@@ -1,0 +1,376 @@
+import numpy as np
+import anytree
+import pytest
+
+import alphaquant.cluster.icc_correction as aq_icc
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic trees
+# ---------------------------------------------------------------------------
+
+def _make_base_node(name, parent, z_val):
+    return anytree.Node(name, parent=parent, type="base", z_val=z_val,
+                        is_included=True, cluster=0)
+
+
+def _make_protein_tree(gene_name, group_zvals, node_type="frgion", p_val=0.5,
+                       group_p_vals=None):
+    """Build a minimal protein tree with one grouping level.
+
+    Args:
+        gene_name: Name for the root (gene) node.
+        group_zvals: list of lists — each inner list holds z-values for
+            one group node's base children.
+        node_type: Type string for the group-level nodes (e.g. "frgion").
+        p_val: Gene-level p-value attached to the root.
+        group_p_vals: Optional list of p-values for the group nodes.
+            If None, each group gets p_val=0.5.
+
+    Returns:
+        anytree.Node: Root of the protein tree.
+    """
+    root = anytree.Node(gene_name, type="gene", p_val=p_val,
+                        is_included=True, cluster=-1)
+    for i, zvals in enumerate(group_zvals):
+        grp_p = group_p_vals[i] if group_p_vals is not None else 0.5
+        grp = anytree.Node(f"{gene_name}_grp{i}", parent=root,
+                           type=node_type, is_included=True, cluster=0,
+                           p_val=grp_p)
+        for j, z in enumerate(zvals):
+            _make_base_node(f"{gene_name}_grp{i}_base{j}", parent=grp, z_val=z)
+    return root
+
+
+def _make_deep_tree(gene_name, p_val=0.5, seed=42):
+    """Build a multi-level tree matching the real hierarchy.
+
+    gene → seq → mod_seq → mod_seq_charge → {frgion, ms1_isotopes} → base
+    """
+    rng = np.random.RandomState(seed)
+    root = anytree.Node(gene_name, type="gene", p_val=p_val,
+                        is_included=True, cluster=-1)
+
+    for s in range(3):
+        seq = anytree.Node(f"{gene_name}_seq{s}", parent=root,
+                           type="seq", is_included=True, cluster=0,
+                           p_val=0.5, z_val=rng.randn())
+        for m in range(2):
+            mod = anytree.Node(f"{gene_name}_seq{s}_mod{m}", parent=seq,
+                               type="mod_seq", is_included=True, cluster=0,
+                               p_val=0.5, z_val=rng.randn())
+            for c in range(2):
+                msc = anytree.Node(f"{gene_name}_seq{s}_mod{m}_ch{c}",
+                                   parent=mod, type="mod_seq_charge",
+                                   is_included=True, cluster=0,
+                                   p_val=0.5, z_val=rng.randn())
+                frg = anytree.Node(f"{gene_name}_seq{s}_mod{m}_ch{c}_frg",
+                                   parent=msc, type="frgion",
+                                   is_included=True, cluster=0,
+                                   p_val=0.5, z_val=rng.randn())
+                for b in range(3):
+                    _make_base_node(
+                        f"{gene_name}_seq{s}_mod{m}_ch{c}_frg_b{b}",
+                        parent=frg, z_val=rng.randn())
+
+                ms1 = anytree.Node(f"{gene_name}_seq{s}_mod{m}_ch{c}_ms1",
+                                   parent=msc, type="ms1_isotopes",
+                                   is_included=True, cluster=0,
+                                   p_val=0.5, z_val=rng.randn())
+                for b in range(2):
+                    _make_base_node(
+                        f"{gene_name}_seq{s}_mod{m}_ch{c}_ms1_b{b}",
+                        parent=ms1, z_val=rng.randn())
+    return root
+
+
+# ---------------------------------------------------------------------------
+# _compute_icc_from_tree  (works at any level now)
+# ---------------------------------------------------------------------------
+
+class TestComputeIccFromTree:
+    def test_returns_none_when_no_matching_nodes(self):
+        root = _make_protein_tree("P1", [[0.1, 0.2], [0.3, 0.4]], node_type="frgion")
+        assert aq_icc._compute_icc_from_tree(root, "ms1_isotopes") is None
+
+    def test_returns_none_when_too_few_groups(self):
+        root = _make_protein_tree("P1", [[0.1, 0.2, 0.3]], node_type="frgion")
+        assert aq_icc._compute_icc_from_tree(root, "frgion") is None
+
+    def test_returns_none_when_too_few_ions(self):
+        root = _make_protein_tree("P1", [[0.1], [0.2], [0.3]], node_type="frgion")
+        assert aq_icc._compute_icc_from_tree(root, "frgion") is None
+
+    def test_identical_within_group_gives_high_icc(self):
+        group_zvals = [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]
+        root = _make_protein_tree("P1", group_zvals, node_type="frgion")
+        icc = aq_icc._compute_icc_from_tree(root, "frgion")
+        assert icc is not None
+        assert icc > 0.9
+
+    def test_no_between_group_variance_gives_zero_icc(self):
+        rng = np.random.RandomState(42)
+        group_zvals = [list(rng.randn(5)) for _ in range(5)]
+        for gv in group_zvals:
+            m = np.mean(gv)
+            for i in range(len(gv)):
+                gv[i] -= m
+        root = _make_protein_tree("P1", group_zvals, node_type="frgion")
+        icc = aq_icc._compute_icc_from_tree(root, "frgion")
+        assert icc is not None
+        assert icc < 0.1
+
+    def test_icc_between_zero_and_one(self):
+        rng = np.random.RandomState(99)
+        group_zvals = [list(rng.randn(4) + i) for i in range(4)]
+        root = _make_protein_tree("P1", group_zvals, node_type="frgion")
+        icc = aq_icc._compute_icc_from_tree(root, "frgion")
+        assert icc is not None
+        assert 0.0 <= icc <= 1.0
+
+    def test_works_with_non_base_children(self):
+        """ICC at mod_seq_charge level uses ion-type children (not base)."""
+        root = _make_deep_tree("P1")
+        icc = aq_icc._compute_icc_from_tree(root, "mod_seq_charge")
+        assert icc is None or 0.0 <= icc <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _collect_group_zvals  (generalized for any level)
+# ---------------------------------------------------------------------------
+
+class TestCollectGroupZvals:
+    def test_collects_base_children_for_frgion(self):
+        group_zvals = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+        root = _make_protein_tree("P1", group_zvals, node_type="frgion")
+        result = aq_icc._collect_group_zvals(root, "frgion")
+        assert len(result) == 3
+        np.testing.assert_array_equal(result[0], [1.0, 2.0])
+
+    def test_collects_non_base_children_for_higher_levels(self):
+        """At mod_seq_charge level, children are frgion/ms1_isotopes nodes."""
+        root = _make_deep_tree("P1")
+        result = aq_icc._collect_group_zvals(root, "mod_seq_charge")
+        assert len(result) > 0
+        for arr in result:
+            assert len(arr) >= 1
+
+    def test_gene_level_returns_empty_due_to_single_group(self):
+        """A single protein has 1 gene node → 1 group < _MIN_GROUPS → empty.
+
+        Gene-level ICC uses the separate _estimate_gene_level_icc path.
+        """
+        root = _make_deep_tree("P1")
+        result = aq_icc._collect_group_zvals(root, "gene")
+        assert result == []
+
+    def test_filters_by_p_val_threshold(self):
+        group_zvals = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
+        group_p_vals = [0.5, 0.5, 0.01, 0.5]
+        root = _make_protein_tree("P1", group_zvals, p_val=0.5,
+                                  group_p_vals=group_p_vals)
+        result = aq_icc._collect_group_zvals(root, "frgion",
+                                             node_p_val_threshold=0.1)
+        assert len(result) == 3
+
+    def test_empty_when_all_filtered(self):
+        group_zvals = [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
+        group_p_vals = [0.01, 0.01, 0.01]
+        root = _make_protein_tree("P1", group_zvals, p_val=0.5,
+                                  group_p_vals=group_p_vals)
+        result = aq_icc._collect_group_zvals(root, "frgion",
+                                             node_p_val_threshold=0.1)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _estimate_null_icc_distribution
+# ---------------------------------------------------------------------------
+
+class TestEstimateNullIccDistribution:
+    def test_only_null_proteins_are_used(self):
+        sig = _make_protein_tree("sig", [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                                 p_val=0.01)
+        null = _make_protein_tree("null", [[0.1, 0.1, 0.1], [0.2, 0.2, 0.2],
+                                           [0.3, 0.3, 0.3]], p_val=0.5)
+        null_iccs, perm_iccs, median = aq_icc._estimate_null_icc_distribution(
+            [sig, null], "frgion"
+        )
+        assert len(null_iccs) == 1
+        assert len(perm_iccs) > 0
+
+    def test_empty_when_no_null_proteins(self):
+        sig = _make_protein_tree("sig", [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                                 p_val=0.01)
+        null_iccs, perm_iccs, median = aq_icc._estimate_null_icc_distribution(
+            [sig], "frgion"
+        )
+        assert null_iccs == []
+        assert perm_iccs == []
+        assert median == 0.0
+
+    def test_permutation_null_near_zero(self):
+        rng = np.random.RandomState(7)
+        group_zvals = [list(rng.randn(5) + offset) for offset in range(5)]
+        root = _make_protein_tree("null", group_zvals, p_val=0.5)
+        null_iccs, perm_iccs, median = aq_icc._estimate_null_icc_distribution(
+            [root], "frgion"
+        )
+        assert len(perm_iccs) > 0
+        assert np.median(perm_iccs) < median
+
+    def test_significant_group_nodes_excluded_from_null(self):
+        """Group nodes with p_val <= threshold should be dropped during null estimation."""
+        group_zvals = [[1.0, 1.1, 0.9], [2.0, 2.3, 1.7],
+                       [3.0, 3.5, 2.5], [4.0, 3.8, 4.2]]
+        group_p_vals = [0.5, 0.5, 0.01, 0.5]
+        root = _make_protein_tree("null", group_zvals, p_val=0.5,
+                                  group_p_vals=group_p_vals)
+        icc_filtered = aq_icc._compute_icc_from_tree(
+            root, "frgion", node_p_val_threshold=0.1
+        )
+        icc_unfiltered = aq_icc._compute_icc_from_tree(root, "frgion")
+        assert icc_filtered is not None
+        assert icc_unfiltered is not None
+        assert icc_filtered != icc_unfiltered
+
+    def test_all_group_nodes_significant_returns_none(self):
+        group_zvals = [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
+        group_p_vals = [0.01, 0.01, 0.01]
+        root = _make_protein_tree("null", group_zvals, p_val=0.5,
+                                  group_p_vals=group_p_vals)
+        icc = aq_icc._compute_icc_from_tree(
+            root, "frgion", node_p_val_threshold=0.1
+        )
+        assert icc is None
+
+
+# ---------------------------------------------------------------------------
+# _estimate_gene_level_icc
+# ---------------------------------------------------------------------------
+
+class TestEstimateGeneLevelIcc:
+    def _make_null_proteins(self, n_proteins=20, n_peptides_range=(3, 8),
+                            p_val=0.5, seed=42):
+        """Create a list of protein trees with seq children carrying z-values."""
+        rng = np.random.RandomState(seed)
+        protnodes = []
+        for i in range(n_proteins):
+            n_pep = rng.randint(n_peptides_range[0], n_peptides_range[1] + 1)
+            root = anytree.Node(f"prot{i}", type="gene", p_val=p_val,
+                                is_included=True, cluster=-1)
+            for j in range(n_pep):
+                anytree.Node(f"prot{i}_seq{j}", parent=root,
+                             type="seq", is_included=True, cluster=0,
+                             z_val=rng.randn())
+            protnodes.append(root)
+        return protnodes
+
+    def test_returns_icc_distribution(self):
+        protnodes = self._make_null_proteins(n_proteins=20)
+        null_iccs, perm_iccs, median = aq_icc._estimate_gene_level_icc(protnodes)
+        assert len(null_iccs) > 0
+        assert len(perm_iccs) > 0
+        assert 0.0 <= median <= 1.0
+
+    def test_fallback_when_too_few_proteins(self):
+        protnodes = self._make_null_proteins(n_proteins=3)
+        null_iccs, perm_iccs, median = aq_icc._estimate_gene_level_icc(protnodes)
+        assert null_iccs == []
+        assert median == 0.0
+
+    def test_excludes_significant_proteins(self):
+        null_prots = self._make_null_proteins(n_proteins=20, p_val=0.5)
+        sig_prots = self._make_null_proteins(n_proteins=5, p_val=0.01, seed=99)
+        all_prots = null_prots + sig_prots
+        null_iccs, _, median = aq_icc._estimate_gene_level_icc(all_prots)
+        assert len(null_iccs) > 0
+
+    def test_excludes_proteins_with_single_peptide(self):
+        """Proteins with only 1 seq child should be skipped."""
+        protnodes = []
+        for i in range(20):
+            root = anytree.Node(f"prot{i}", type="gene", p_val=0.5,
+                                is_included=True, cluster=-1)
+            anytree.Node(f"prot{i}_seq0", parent=root, type="seq",
+                         is_included=True, cluster=0, z_val=0.1)
+            protnodes.append(root)
+        null_iccs, _, median = aq_icc._estimate_gene_level_icc(protnodes)
+        assert null_iccs == []
+        assert median == 0.0
+
+    def test_shuffled_lower_than_observed_for_correlated_data(self):
+        """When peptides within proteins are correlated, permutation ICC < observed."""
+        rng = np.random.RandomState(77)
+        protnodes = []
+        for i in range(30):
+            root = anytree.Node(f"prot{i}", type="gene", p_val=0.5,
+                                is_included=True, cluster=-1)
+            protein_effect = rng.randn() * 2
+            for j in range(5):
+                anytree.Node(f"prot{i}_seq{j}", parent=root, type="seq",
+                             is_included=True, cluster=0,
+                             z_val=protein_effect + rng.randn() * 0.3)
+            protnodes.append(root)
+        null_iccs, perm_iccs, median = aq_icc._estimate_gene_level_icc(protnodes)
+        assert np.median(perm_iccs) < median
+
+
+# ---------------------------------------------------------------------------
+# _assign_icc_to_all_proteins
+# ---------------------------------------------------------------------------
+
+class TestAssignIccToAllProteins:
+    def test_assigns_uniform_icc_to_all_nodes(self):
+        root = _make_protein_tree("P1", [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                                  node_type="frgion")
+        icc_median = 0.25
+        n = aq_icc._assign_icc_to_all_proteins([root], "frgion", icc_median)
+        assert n == 3
+        for node in anytree.search.findall(root, filter_=lambda n: n.type == "frgion"):
+            assert node.icc_correction == icc_median
+
+    def test_returns_zero_when_no_matching_nodes(self):
+        root = _make_protein_tree("P1", [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                                  node_type="frgion")
+        n = aq_icc._assign_icc_to_all_proteins([root], "ms1_isotopes", 0.3)
+        assert n == 0
+
+    def test_assigns_to_gene_node(self):
+        root = _make_protein_tree("P1", [[1, 2], [3, 4], [5, 6]],
+                                  node_type="frgion")
+        n = aq_icc._assign_icc_to_all_proteins([root], "gene", 0.15)
+        assert n == 1
+        assert root.icc_correction == 0.15
+
+    def test_assigns_to_higher_level_nodes(self):
+        root = _make_deep_tree("P1")
+        n = aq_icc._assign_icc_to_all_proteins([root], "mod_seq_charge", 0.1)
+        msc_nodes = anytree.search.findall(root, filter_=lambda n: n.type == "mod_seq_charge")
+        assert n == len(msc_nodes)
+        for node in msc_nodes:
+            assert node.icc_correction == 0.1
+
+
+# ---------------------------------------------------------------------------
+# _has_node_type
+# ---------------------------------------------------------------------------
+
+class TestHasNodeType:
+    def test_true_when_present(self):
+        root = _make_protein_tree("P1", [[0.1, 0.2]], node_type="frgion")
+        assert aq_icc._has_node_type([root], "frgion") is True
+
+    def test_false_when_absent(self):
+        root = _make_protein_tree("P1", [[0.1, 0.2]], node_type="frgion")
+        assert aq_icc._has_node_type([root], "ms1_isotopes") is False
+
+    def test_gene_type_found_at_root(self):
+        root = _make_protein_tree("P1", [[0.1, 0.2]], node_type="frgion")
+        assert aq_icc._has_node_type([root], "gene") is True
+
+    def test_deep_tree_has_all_types(self):
+        root = _make_deep_tree("P1")
+        for node_type in ("gene", "seq", "mod_seq", "mod_seq_charge",
+                          "frgion", "ms1_isotopes", "base"):
+            assert aq_icc._has_node_type([root], node_type) is True


### PR DESCRIPTION
## Summary
- Adds `icc_correction.py`: estimates a global intraclass correlation (ICC) from null proteins and applies it as a design-effect correction to Stouffer z-score aggregation, improving calibration under correlated replicates
- Includes full unit test suite

## Notes
Part of the residual decorrelation PR stack. Stacked on #132.