### PR TITLE
Mark pandas<3 as tolerated version pin in loose requirements

### DIFF
--- a/requirements/requirements_loose.txt
+++ b/requirements/requirements_loose.txt
@@ -1,7 +1,7 @@
 numpy
 numba
 statsmodels
-pandas<3
+pandas<3  # test:tolerate_version
 scipy
 matplotlib
 seaborn


### PR DESCRIPTION
## Summary
- The `pandas<3` upper bound was intentionally pinned in PR #122 (pandas 3 compatibility not yet verified)
- The requirements test (added in PR #41) enforces that loose requirements have no version specifiers, unless marked with `# test:tolerate_version`
- This PR adds that comment so CI passes

## Test plan
- [ ] `pytest tests/pytest/test_requirements.py` passes